### PR TITLE
chore: update dependencies and enhance JSON repair functionality

### DIFF
--- a/.changeset/busy-mangos-rush.md
+++ b/.changeset/busy-mangos-rush.md
@@ -1,0 +1,23 @@
+---
+'ai-sdk-ollama': minor
+---
+
+Enhanced JSON repair for reliable object generation
+
+- **New Feature**: Added `enhancedRepairText` function that automatically fixes 14+ types of common JSON issues from LLM outputs
+- **Improved Reliability**: Enhanced `objectGenerationOptions` with comprehensive JSON repair capabilities including:
+  - Markdown code block extraction
+  - Comment removal
+  - Smart quote fixing
+  - Unquoted key handling
+  - Trailing comma removal
+  - Incomplete object/array completion
+  - Python constant conversion (True/False/None)
+  - JSONP wrapper removal
+  - Single quote to double quote conversion
+  - URL and escaped quote handling
+  - Ellipsis pattern resolution
+- **New Example**: Added `json-repair-example.ts` demonstrating enhanced repair capabilities
+- **Enhanced Configuration**: `enableTextRepair` now defaults to `true` for better out-of-the-box reliability
+- **Comprehensive Testing**: Added extensive test suite covering all repair scenarios
+- **Backward Compatible**: All existing functionality remains unchanged

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ console.log(text);
 - ✅ **Solves tool calling problems** - Response synthesis for reliable tool execution
 - ✅ **Enhanced wrapper functions** - `generateText` and `streamText` guarantees complete responses
 - ✅ **Built-in reliability** - Default reliability features enabled automatically
+- ✅ **Automatic JSON repair** - Fixes malformed JSON from LLM outputs (trailing commas, comments, URLs, Python constants, etc.)
 - ✅ **Web search and fetch tools** - Built-in web search and fetch tools powered by [Ollama's web search API](https://ollama.com/blog/web-search). Perfect for getting current information and reducing hallucinations.
 - ✅ **Type-safe** - Full TypeScript support with strict typing
 - ✅ **Cross-environment** - Works in Node.js and browsers automatically

--- a/examples/node/src/json-repair-example.ts
+++ b/examples/node/src/json-repair-example.ts
@@ -1,0 +1,137 @@
+import { generateObject } from 'ai';
+import { ollama } from 'ai-sdk-ollama';
+import { z } from 'zod';
+
+/**
+ * Example demonstrating enhanced JSON repair for object generation with Ollama
+ *
+ * This example shows how the enhanced JSON repair automatically fixes
+ * common JSON issues from LLM outputs.
+ */
+
+async function main() {
+  console.log('🔧 JSON Repair Example\n');
+
+  try {
+    // Example 1: Basic object generation with automatic repair
+    console.log('📝 Example 1: Basic object generation (repair enabled by default)');
+    const result1 = await generateObject({
+      model: ollama('llama3.2', {
+        structuredOutputs: true,
+        // Enhanced JSON repair is enabled by default
+        reliableObjectGeneration: true,
+      }),
+      schema: z.object({
+        name: z.string(),
+        email: z.string().email(),
+        age: z.number(),
+        city: z.string(),
+      }),
+      prompt: 'Generate a person profile for John Doe, 30 years old, from New York',
+    });
+
+    console.log('✅ Generated object:', JSON.stringify(result1.object, null, 2));
+    console.log();
+
+    // Example 2: Complex nested object with automatic repair
+    console.log('📝 Example 2: Complex nested object');
+    const result2 = await generateObject({
+      model: ollama('llama3.2', {
+        structuredOutputs: true,
+        reliableObjectGeneration: true,
+      }),
+      schema: z.object({
+        recipe: z.object({
+          name: z.string(),
+          ingredients: z.array(
+            z.object({
+              name: z.string(),
+              amount: z.string(),
+            }),
+          ),
+          steps: z.array(z.string()),
+          cookingTime: z.number().describe('Cooking time in minutes'),
+        }),
+      }),
+      prompt: 'Generate a simple pasta recipe with at least 3 ingredients and 3 steps',
+    });
+
+    console.log('✅ Generated recipe:', JSON.stringify(result2.object, null, 2));
+    console.log();
+
+    // Example 3: Disable reliability (not recommended)
+    console.log('📝 Example 3: Reliability disabled (may fail with malformed JSON)');
+    try {
+      const result3 = await generateObject({
+        model: ollama('llama3.2', {
+          structuredOutputs: true,
+          reliableObjectGeneration: false, // Disable all reliability features
+        }),
+        schema: z.object({
+          message: z.string(),
+        }),
+        prompt: 'Generate a simple message',
+      });
+      console.log('✅ Succeeded without reliability:', JSON.stringify(result3.object, null, 2));
+    } catch (error) {
+      console.log('❌ Failed (as expected):', (error as Error).message);
+    }
+    console.log();
+
+    // Example 4: Fine-grained control - disable only repair, keep retries
+    console.log('📝 Example 4: Retries enabled, repair disabled');
+    try {
+      const result4 = await generateObject({
+        model: ollama('llama3.2', {
+          structuredOutputs: true,
+          reliableObjectGeneration: true,
+          objectGenerationOptions: {
+            enableTextRepair: false, // Disable repair only
+            maxRetries: 3, // But keep retries
+          },
+        }),
+        schema: z.object({
+          message: z.string(),
+        }),
+        prompt: 'Generate a simple message',
+      });
+      console.log('✅ Succeeded with retries but no repair:', JSON.stringify(result4.object, null, 2));
+    } catch (error) {
+      console.log('❌ Failed:', (error as Error).message);
+    }
+    console.log();
+
+    // Example 5: Custom repair function
+    console.log('📝 Example 5: Using custom repair function');
+    const result5 = await generateObject({
+      model: ollama('llama3.2', {
+        structuredOutputs: true,
+        reliableObjectGeneration: true,
+        objectGenerationOptions: {
+          repairText: async ({ text, error }) => {
+            console.log('  🔍 Custom repair function called');
+            console.log('  📄 Original text:', text.slice(0, 100) + '...');
+            console.log('  ❌ Error:', error.message);
+
+            // Simple custom repair: just remove trailing comma
+            const repaired = text.replace(/,(\s*[}\]])/g, '$1');
+            return repaired;
+          },
+        },
+      }),
+      schema: z.object({
+        title: z.string(),
+        description: z.string(),
+      }),
+      prompt: 'Generate a title and description for a blog post about AI',
+    });
+
+    console.log('✅ Generated post:', JSON.stringify(result5.object, null, 2));
+    console.log('\n✨ JSON repair examples completed!');
+  } catch (error) {
+    console.error('❌ Error:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
-    "@eslint/js": "^9.36.0",
+    "@eslint/js": "^9.37.0",
     "@typescript-eslint/eslint-plugin": "^8.45.0",
     "@typescript-eslint/parser": "^8.45.0",
-    "eslint": "^9.36.0",
+    "eslint": "^9.37.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-unicorn": "^61.0.2",
     "prettier": "^3.6.2",
@@ -36,11 +36,24 @@
     "node": ">=22",
     "pnpm": ">=8"
   },
-  "packageManager": "pnpm@10.17.1",
+  "packageManager": "pnpm@10.18.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jagreehal/ai-sdk-ollama.git"
   },
-  "author": "Jag Reehal<jag@jagreehal.com> (https://jagreehal.com)",
-  "license": "MIT"
+  "author": "Jag Reehal <jag@jagreehal.com> (https://jagreehal.com)",
+  "license": "MIT",
+  "main": "index.js",
+  "directories": {
+    "example": "examples"
+  },
+  "dependencies": {
+    "eslint-scope": "^8.4.0",
+    "eslint-visitor-keys": "^4.2.1"
+  },
+  "keywords": [],
+  "bugs": {
+    "url": "https://github.com/jagreehal/ai-sdk-ollama/issues"
+  },
+  "homepage": "https://github.com/jagreehal/ai-sdk-ollama#readme"
 }

--- a/packages/ai-sdk-ollama/src/provider.ts
+++ b/packages/ai-sdk-ollama/src/provider.ts
@@ -10,6 +10,7 @@ import { OllamaEmbeddingModel } from './models/embedding-model';
 import { ollamaTools } from './ollama-tools';
 import type { WebSearchToolOptions } from './tool/web-search';
 import type { WebFetchToolOptions } from './tool/web-fetch';
+import type { ObjectGenerationOptions } from './utils/object-generation-reliability';
 
 // Extend Ollama Options to include missing parameters
 export interface Options extends OllamaOptions {
@@ -164,39 +165,9 @@ export interface OllamaChatSettings {
   /**
    * Object generation reliability options. These override the sensible defaults used by the
    * built-in reliability layer (maxRetries=3, attemptRecovery=true, useFallbacks=true,
-   * fixTypeMismatches=true).
+   * fixTypeMismatches=true, enableTextRepair=true).
    */
-  objectGenerationOptions?: {
-    /**
-     * Maximum number of retry attempts for object generation
-     */
-    maxRetries?: number;
-
-    /**
-     * Whether to attempt schema recovery when validation fails
-     */
-    attemptRecovery?: boolean;
-
-    /**
-     * Whether to use fallback values for failed generations
-     */
-    useFallbacks?: boolean;
-
-    /**
-     * Custom fallback values for specific fields
-     */
-    fallbackValues?: Record<string, unknown>;
-
-    /**
-     * Timeout for object generation in milliseconds
-     */
-    generationTimeout?: number;
-
-    /**
-     * Whether to validate and fix type mismatches
-     */
-    fixTypeMismatches?: boolean;
-  };
+  objectGenerationOptions?: ObjectGenerationOptions;
 
   /**
    * Additional model parameters - re-exported from ollama-js

--- a/packages/ai-sdk-ollama/src/utils/object-generation-reliability-url.test.ts
+++ b/packages/ai-sdk-ollama/src/utils/object-generation-reliability-url.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { enhancedRepairText } from './object-generation-reliability';
+
+describe('Enhanced JSON Repair - URL Handling', () => {
+  it('should preserve URLs with // inside single-quoted strings', async () => {
+    const input = "{'url': 'https://example.com', 'name': 'foo'}";
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.url).toBe('https://example.com');
+    expect(parsed.name).toBe('foo');
+  });
+
+  it('should preserve URLs with // inside double-quoted strings', async () => {
+    const input = '{"url": "https://example.com", "name": "bar"}';
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.url).toBe('https://example.com');
+    expect(parsed.name).toBe('bar');
+  });
+
+  it('should handle multiple URLs in the same object', async () => {
+    const input = `{
+      api: 'https://api.example.com',
+      website: 'http://example.com',
+      // This is a comment
+      cdn: 'https://cdn.example.com'
+    }`;
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.api).toBe('https://api.example.com');
+    expect(parsed.website).toBe('http://example.com');
+    expect(parsed.cdn).toBe('https://cdn.example.com');
+  });
+
+  it('should remove actual comments while preserving URLs', async () => {
+    const input = `{
+      url: 'https://example.com',
+      path: '/api/v1'
+    }`;
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.url).toBe('https://example.com');
+    expect(parsed.path).toBe('/api/v1');
+  });
+
+  it('should handle protocol-relative URLs', async () => {
+    const input = "{url: '//example.com/path', secure: false}";
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.url).toBe('//example.com/path');
+    expect(parsed.secure).toBe(false);
+  });
+
+  it('should preserve // in strings with escaped single quotes', async () => {
+    const input = String.raw`{'description': 'It\'s not // comment', 'value': 42}`;
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.description).toBe("It's not // comment");
+    expect(parsed.value).toBe(42);
+  });
+
+  it('should preserve // in strings with escaped double quotes', async () => {
+    const input = String.raw`{"text": "He said \"It's // fine\"", "ok": true}`;
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.text).toBe('He said "It\'s // fine"');
+    expect(parsed.ok).toBe(true);
+  });
+
+  it('should remove actual comments but preserve // in strings with escaped quotes', async () => {
+    const input = `{
+      url: 'https://example.com',
+      desc: 'A URL // not a comment',
+      // This is an actual comment
+      value: 123
+    }`;
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.url).toBe('https://example.com');
+    expect(parsed.desc).toBe('A URL // not a comment');
+    expect(parsed.value).toBe(123);
+    expect(result).not.toContain('This is an actual comment');
+  });
+
+  it('should handle paths with backslashes and preserve URLs', async () => {
+    const input = String.raw`{"path": "C:\\Program Files\\App", "url": "https://example.com"}`;
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.path).toBe(String.raw`C:\Program Files\App`);
+    expect(parsed.url).toBe('https://example.com');
+  });
+
+  it('should remove trailing comments after URLs in strings', async () => {
+    const input = '{"text": "https://example.com" // this is a comment}';
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.text).toBe('https://example.com');
+    expect(result).not.toContain('this is a comment');
+  });
+
+  it('should handle multiple // on same line - preserve in string, remove comment', async () => {
+    const input = '{"url": "https://example.com", "path": "//cdn.example.com" // comment here}';
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.url).toBe('https://example.com');
+    expect(parsed.path).toBe('//cdn.example.com');
+    expect(result).not.toContain('comment here');
+  });
+
+  it('should remove comment after string with URL on same line', async () => {
+    const input = `{
+      "api": "https://api.example.com", // API endpoint
+      "version": 1
+    }`;
+    const result = await enhancedRepairText({
+      text: input,
+      error: new Error('test'),
+    });
+    const parsed = JSON.parse(result!);
+    expect(parsed.api).toBe('https://api.example.com');
+    expect(parsed.version).toBe(1);
+    expect(result).not.toContain('API endpoint');
+  });
+});

--- a/packages/ai-sdk-ollama/src/utils/object-generation-reliability.test.ts
+++ b/packages/ai-sdk-ollama/src/utils/object-generation-reliability.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { enhancedRepairText, getRepairFunction } from './object-generation-reliability';
+
+describe('Enhanced JSON Repair', () => {
+  describe('enhancedRepairText', () => {
+    it('should extract JSON from markdown code blocks', async () => {
+      const input = '```json\n{"name": "John"}\n```';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(result).toBe('{"name": "John"}');
+    });
+
+    it('should remove comments', async () => {
+      const input = '{\n  // this is a comment\n  "name": "John"\n}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(result).not.toContain('//');
+      expect(JSON.parse(result!)).toEqual({ name: 'John' });
+    });
+
+    it('should fix smart quotes', async () => {
+      const input = '{"name": "John"}'; // curly quotes
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ name: 'John' });
+    });
+
+    it('should fix unquoted keys', async () => {
+      const input = '{name: "John", age: 30}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ name: 'John', age: 30 });
+    });
+
+    it('should remove trailing commas', async () => {
+      const input = '{"name": "John", "age": 30,}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ name: 'John', age: 30 });
+    });
+
+    it('should fix incomplete objects', async () => {
+      const input = '{"name": "John", "age": 30';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ name: 'John', age: 30 });
+    });
+
+    it('should fix incomplete arrays', async () => {
+      const input = '[1, 2, 3';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual([1, 2, 3]);
+    });
+
+    it('should handle ellipsis patterns', async () => {
+      const input = '{"items": [1, 2, ..., 5]}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      const parsed = JSON.parse(result!);
+      expect(Array.isArray(parsed.items)).toBe(true);
+    });
+
+    it('should fix single quotes', async () => {
+      const input = "{'name': 'John', 'age': 30}";
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ name: 'John', age: 30 });
+    });
+
+    it('should handle complex nested objects', async () => {
+      const input = `{
+        name: 'John',
+        address: {
+          city: 'New York',
+          zip: 10001,
+        }
+      }`;
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({
+        name: 'John',
+        address: {
+          city: 'New York',
+          zip: 10_001,
+        },
+      });
+    });
+
+    it('should fix Python constants', async () => {
+      const input = '{name: "John", active: True, value: None, disabled: False}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({
+        name: 'John',
+        active: true,
+        value: null,
+        disabled: false,
+      });
+    });
+
+    it('should remove JSONP wrapper', async () => {
+      const input = 'callback({"name": "John"})';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ name: 'John' });
+    });
+
+    it('should return null for completely invalid JSON', async () => {
+      const input = 'this is not json at all';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getRepairFunction', () => {
+    it('should return custom repair function if provided', () => {
+      const customRepair = async () => null;
+      const result = getRepairFunction({ repairText: customRepair });
+      expect(result).toBe(customRepair);
+    });
+
+    it('should return undefined if text repair is disabled', () => {
+      const result = getRepairFunction({ enableTextRepair: false });
+      expect(result).toBeUndefined();
+    });
+
+    it('should return enhanced repair by default', () => {
+      const result = getRepairFunction({});
+      expect(result).toBe(enhancedRepairText);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,28 +7,35 @@ settings:
 importers:
 
   .:
+    dependencies:
+      eslint-scope:
+        specifier: ^8.4.0
+        version: 8.4.0
+      eslint-visitor-keys:
+        specifier: ^4.2.1
+        version: 4.2.1
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.7
         version: 2.29.7(@types/node@24.6.2)
       '@eslint/js':
-        specifier: ^9.36.0
-        version: 9.36.0
+        specifier: ^9.37.0
+        version: 9.37.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.45.0
-        version: 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
+        version: 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.45.0
-        version: 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
+        version: 8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
       eslint:
-        specifier: ^9.36.0
-        version: 9.36.0(jiti@2.6.0)
+        specifier: ^9.37.0
+        version: 9.37.0(jiti@2.6.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.36.0(jiti@2.6.0))
+        version: 10.1.8(eslint@9.37.0(jiti@2.6.0))
       eslint-plugin-unicorn:
         specifier: ^61.0.2
-        version: 61.0.2(eslint@9.36.0(jiti@2.6.0))
+        version: 61.0.2(eslint@9.37.0(jiti@2.6.0))
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -37,7 +44,7 @@ importers:
         version: 2.5.8
       typescript-eslint:
         specifier: ^8.45.0
-        version: 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
+        version: 8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
 
   examples/browser:
     dependencies:
@@ -217,16 +224,16 @@ importers:
         version: 24.6.2
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.45.0
-        version: 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
+        version: 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.45.0
-        version: 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
+        version: 8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.36.0(jiti@2.6.0))
+        version: 10.1.8(eslint@9.37.0(jiti@2.6.0))
       eslint-plugin-unicorn:
         specifier: ^61.0.2
-        version: 61.0.2(eslint@9.36.0(jiti@2.6.0))
+        version: 61.0.2(eslint@9.37.0(jiti@2.6.0))
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -241,7 +248,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.45.0
-        version: 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
+        version: 8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.3)(vite@7.1.9(@types/node@24.6.2)(jiti@2.6.0)(lightningcss@1.30.1)(tsx@4.20.6))
@@ -259,12 +266,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
-
-  '@ai-sdk/gateway@1.0.32':
-    resolution: {integrity: sha512-TQRIM63EI/ccJBc7RxeB8nq/CnGNnyl7eu5stWdLwL41stkV5skVeZJe0QRvFbaOrwCkgUVE0yrUqJi4tgDC1A==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/gateway@1.0.33':
     resolution: {integrity: sha512-v9i3GPEo4t3fGcSkQkc07xM6KJN75VUv7C1Mqmmsu2xD8lQwnQfsrgAXyNuWe20yGY0eHuheSPDZhiqsGKtH1g==}
@@ -744,20 +745,24 @@ packages:
     resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.3.1':
-    resolution: {integrity: sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==}
+  '@eslint/config-helpers@0.4.0':
+    resolution: {integrity: sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/core@0.15.2':
     resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/core@0.16.0':
+    resolution: {integrity: sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/eslintrc@3.3.1':
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.36.0':
-    resolution: {integrity: sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==}
+  '@eslint/js@9.37.0':
+    resolution: {integrity: sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.6':
@@ -766,6 +771,10 @@ packages:
 
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.0':
+    resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@floating-ui/core@1.7.3':
@@ -1892,12 +1901,6 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
-  ai@5.0.59:
-    resolution: {integrity: sha512-SuAFxKXt2Ha9FiXB3gaOITkOg9ek/3QNVatGVExvTT4gNXc+hJpuNe1dmuwf6Z5Op4fzc8wdbsrYP27ZCXBzlw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   ai@5.0.60:
     resolution: {integrity: sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA==}
     engines: {node: '>=18'}
@@ -2476,8 +2479,8 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.36.0:
-    resolution: {integrity: sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==}
+  eslint@9.37.0:
+    resolution: {integrity: sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -4226,12 +4229,6 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.9(zod@4.1.11)
       zod: 4.1.11
 
-  '@ai-sdk/gateway@1.0.32(zod@4.1.11)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.10(zod@4.1.11)
-      zod: 4.1.11
-
   '@ai-sdk/gateway@1.0.33(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -4631,14 +4628,14 @@ snapshots:
   '@esbuild/win32-x64@0.25.8':
     optional: true
 
-  '@eslint-community/eslint-utils@4.8.0(eslint@9.36.0(jiti@2.6.0))':
+  '@eslint-community/eslint-utils@4.8.0(eslint@9.37.0(jiti@2.6.0))':
     dependencies:
-      eslint: 9.36.0(jiti@2.6.0)
+      eslint: 9.37.0(jiti@2.6.0)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.36.0(jiti@2.6.0))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.37.0(jiti@2.6.0))':
     dependencies:
-      eslint: 9.36.0(jiti@2.6.0)
+      eslint: 9.37.0(jiti@2.6.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -4651,9 +4648,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.3.1': {}
+  '@eslint/config-helpers@0.4.0':
+    dependencies:
+      '@eslint/core': 0.16.0
 
   '@eslint/core@0.15.2':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/core@0.16.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -4671,13 +4674,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.36.0': {}
+  '@eslint/js@9.37.0': {}
 
   '@eslint/object-schema@2.1.6': {}
 
   '@eslint/plugin-kit@0.3.5':
     dependencies:
       '@eslint/core': 0.15.2
+      levn: 0.4.1
+
+  '@eslint/plugin-kit@0.4.0':
+    dependencies:
+      '@eslint/core': 0.16.0
       levn: 0.4.1
 
   '@floating-ui/core@1.7.3':
@@ -5634,15 +5642,15 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.45.0
-      '@typescript-eslint/type-utils': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.45.0
-      eslint: 9.36.0(jiti@2.6.0)
+      eslint: 9.37.0(jiti@2.6.0)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -5651,14 +5659,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.45.0
       '@typescript-eslint/types': 8.45.0
       '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.45.0
       debug: 4.4.3
-      eslint: 9.36.0(jiti@2.6.0)
+      eslint: 9.37.0(jiti@2.6.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5681,13 +5689,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.45.0
       '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.36.0(jiti@2.6.0)
+      eslint: 9.37.0(jiti@2.6.0)
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5711,13 +5719,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.6.0))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.0))
       '@typescript-eslint/scope-manager': 8.45.0
       '@typescript-eslint/types': 8.45.0
       '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.3)
-      eslint: 9.36.0(jiti@2.6.0)
+      eslint: 9.37.0(jiti@2.6.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5784,14 +5792,6 @@ snapshots:
       '@ai-sdk/gateway': 1.0.25(zod@4.1.11)
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.9(zod@4.1.11)
-      '@opentelemetry/api': 1.9.0
-      zod: 4.1.11
-
-  ai@5.0.59(zod@4.1.11):
-    dependencies:
-      '@ai-sdk/gateway': 1.0.32(zod@4.1.11)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.10(zod@4.1.11)
       '@opentelemetry/api': 1.9.0
       zod: 4.1.11
 
@@ -6359,20 +6359,20 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.36.0(jiti@2.6.0)):
+  eslint-config-prettier@10.1.8(eslint@9.37.0(jiti@2.6.0)):
     dependencies:
-      eslint: 9.36.0(jiti@2.6.0)
+      eslint: 9.37.0(jiti@2.6.0)
 
-  eslint-plugin-unicorn@61.0.2(eslint@9.36.0(jiti@2.6.0)):
+  eslint-plugin-unicorn@61.0.2(eslint@9.37.0(jiti@2.6.0)):
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.36.0(jiti@2.6.0))
+      '@eslint-community/eslint-utils': 4.8.0(eslint@9.37.0(jiti@2.6.0))
       '@eslint/plugin-kit': 0.3.5
       change-case: 5.4.4
       ci-info: 4.3.0
       clean-regexp: 1.0.0
       core-js-compat: 3.45.1
-      eslint: 9.36.0(jiti@2.6.0)
+      eslint: 9.37.0(jiti@2.6.0)
       esquery: 1.6.0
       find-up-simple: 1.0.1
       globals: 16.3.0
@@ -6394,16 +6394,16 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.36.0(jiti@2.6.0):
+  eslint@9.37.0(jiti@2.6.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.8.0(eslint@9.36.0(jiti@2.6.0))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.0))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.21.0
-      '@eslint/config-helpers': 0.3.1
-      '@eslint/core': 0.15.2
+      '@eslint/config-helpers': 0.4.0
+      '@eslint/core': 0.16.0
       '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.36.0
-      '@eslint/plugin-kit': 0.3.5
+      '@eslint/js': 9.37.0
+      '@eslint/plugin-kit': 0.4.0
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
@@ -8199,13 +8199,13 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3):
+  typescript-eslint@8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3))(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.3)
-      eslint: 9.36.0(jiti@2.6.0)
+      '@typescript-eslint/utils': 8.45.0(eslint@9.37.0(jiti@2.6.0))(typescript@5.9.3)
+      eslint: 9.37.0(jiti@2.6.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
- Bump @eslint/js and eslint from 9.36.0 to 9.37.0 for improved linting.
- Update pnpm to version 10.18.0.
- Add automatic JSON repair feature to handle 14+ types of malformed JSON outputs from LLMs, enhancing reliability in object generation.
- Update README files to document the new JSON repair capabilities and usage examples.

This commit improves the overall reliability and usability of the SDK.