### PR TITLE
Enhance README and provider implementation with API key configuration

### DIFF
--- a/.changeset/early-tips-attend.md
+++ b/.changeset/early-tips-attend.md
@@ -1,0 +1,11 @@
+---
+'ai-sdk-ollama': patch
+---
+
+Add API key configuration support for cloud Ollama services
+
+- Added `apiKey` parameter to `createOllama` options
+- API key is automatically set as `Authorization: Bearer {apiKey}` header
+- Existing Authorization headers take precedence over apiKey
+- Added header normalization to handle Headers instances, arrays, and plain objects
+- Updated README with API key configuration examples for different runtimes (Node.js, Bun, Deno, serverless)

--- a/packages/ai-sdk-ollama/README.md
+++ b/packages/ai-sdk-ollama/README.md
@@ -139,6 +139,7 @@ export OLLAMA_API_KEY="your_api_key_here"
     - [Simple and Predictable](#simple-and-predictable)
   - [Advanced Features](#advanced-features)
     - [Custom Ollama Instance](#custom-ollama-instance)
+    - [API Key Configuration](#api-key-configuration)
     - [Using Existing Ollama Client](#using-existing-ollama-client)
     - [Structured Output](#structured-output)
     - [Auto-Detection of Structured Outputs](#auto-detection-of-structured-outputs)
@@ -454,6 +455,57 @@ const { text } = await generateText({
   prompt: 'Hello!',
 });
 ```
+
+### API Key Configuration
+
+For cloud Ollama services, pass your API key explicitly using `createOllama`:
+
+```typescript
+import { createOllama } from 'ai-sdk-ollama';
+
+const ollama = createOllama({
+  apiKey: process.env.OLLAMA_API_KEY,
+  baseURL: 'https://ollama.com',
+});
+
+const { text } = await generateText({
+  model: ollama('llama3.2'),
+  prompt: 'Hello!',
+});
+```
+
+**Why explicit over auto-detection?**
+
+Different runtimes handle environment variables differently:
+
+| Runtime | `.env` Auto-Loading |
+|---------|---------------------|
+| Node.js | ❌ No (requires `dotenv`) |
+| Bun | ✅ Yes (usually) |
+| Deno | ❌ No |
+| Edge/Serverless | ❌ No (platform injects vars) |
+
+Passing `apiKey` explicitly works reliably everywhere and avoids surprises.
+
+**Runtime-specific examples:**
+
+```typescript
+// Node.js (with dotenv)
+import 'dotenv/config';
+const ollama = createOllama({ apiKey: process.env.OLLAMA_API_KEY });
+
+// Bun
+const ollama = createOllama({ apiKey: Bun.env.OLLAMA_API_KEY });
+
+// Deno
+const ollama = createOllama({ apiKey: Deno.env.get('OLLAMA_API_KEY') });
+
+// Production (Vercel, Railway, Fly.io, etc.)
+// Env vars are injected by the platform - no .env files needed
+const ollama = createOllama({ apiKey: process.env.OLLAMA_API_KEY });
+```
+
+**Note**: The API key is set as `Authorization: Bearer {apiKey}` header. If you provide both an `apiKey` and a pre-existing `Authorization` header, the existing header takes precedence.
 
 ### Using Existing Ollama Client
 

--- a/packages/ai-sdk-ollama/src/provider.browser.ts
+++ b/packages/ai-sdk-ollama/src/provider.browser.ts
@@ -26,17 +26,75 @@ import type {
 } from './provider';
 
 /**
+ * Type guard to check if an object is Headers-like (has entries method)
+ */
+function isHeadersLike(
+  obj: unknown,
+): obj is { entries: () => IterableIterator<[string, string]> } {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'entries' in obj &&
+    typeof (obj as { entries: unknown }).entries === 'function'
+  );
+}
+
+/**
+ * Normalize HeadersInit to a plain object for safe merging
+ */
+function normalizeHeaders(
+  headers: Record<string, string> | Headers | [string, string][] | undefined,
+): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+
+  // If it's an array of [key, value] tuples, convert first
+  if (Array.isArray(headers)) {
+    const result: Record<string, string> = {};
+    for (const [key, value] of headers) {
+      result[key] = value;
+    }
+    return result;
+  }
+
+  // If it's a Headers instance (check by method presence, not instanceof for cross-context compatibility)
+  if (isHeadersLike(headers)) {
+    const result: Record<string, string> = {};
+    for (const [key, value] of headers.entries()) {
+      result[key] = value;
+    }
+    return result;
+  }
+
+  // If it's already a plain object, return it
+  if (typeof headers === 'object') {
+    return headers as Record<string, string>;
+  }
+
+  return {};
+}
+
+/**
  * Create an Ollama provider instance for browser environments
  */
 export function createOllama(
   options: OllamaProviderSettings = {},
 ): OllamaProvider {
+  // Normalize headers to a plain object for safe merging
+  const normalizedHeaders = normalizeHeaders(options.headers);
+
+  // Add Authorization header if apiKey is available and not already set
+  if (options.apiKey && !normalizedHeaders.Authorization && !normalizedHeaders.authorization) {
+    normalizedHeaders.Authorization = `Bearer ${options.apiKey}`;
+  }
+
   // Create browser-compatible Ollama client
   // Cast to Ollama type for compatibility with shared model code
   const client = new OllamaBrowser({
     host: options.baseURL,
     fetch: options.fetch,
-    headers: options.headers,
+    headers: Object.keys(normalizedHeaders).length > 0 ? normalizedHeaders : undefined,
   }) as unknown as Ollama;
 
   const createChatModel = (

--- a/packages/ai-sdk-ollama/src/provider.test.ts
+++ b/packages/ai-sdk-ollama/src/provider.test.ts
@@ -2,10 +2,39 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Ollama } from 'ollama';
 import { createOllama } from './provider';
 
+// Mock the ollama module to capture constructor calls
+type OllamaConfig = { headers?: Record<string, string> | Headers | [string, string][] };
+
+// Augment globalThis with proper typing to store captured configs
+// This avoids 'as any' while working around vi.mock hoisting
+declare global {
+  // eslint-disable-next-line no-var
+  var __capturedOllamaConfigs: OllamaConfig[];
+}
+
+vi.mock('ollama', async () => {
+  const actual = await vi.importActual<typeof import('ollama')>('ollama');
+  return {
+    ...actual,
+    Ollama: class MockOllama extends actual.Ollama {
+      constructor(config?: OllamaConfig) {
+        globalThis.__capturedOllamaConfigs = globalThis.__capturedOllamaConfigs ?? [];
+        globalThis.__capturedOllamaConfigs.push(config ?? {});
+        super(config);
+      }
+    },
+  };
+});
+
 describe('createOllama', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    globalThis.__capturedOllamaConfigs = [];
   });
+
+  function getCapturedConfigs(): OllamaConfig[] {
+    return globalThis.__capturedOllamaConfigs ?? [];
+  }
 
   it('should create a new Ollama client when no client is provided', () => {
     const provider = createOllama({
@@ -99,5 +128,105 @@ describe('createOllama', () => {
     const chatModel = provider('llama3.2');
     expect(chatModel).toBeDefined();
     expect(chatModel.modelId).toBe('llama3.2');
+  });
+
+  it('should set Authorization header when apiKey is provided', () => {
+    const provider = createOllama({
+      apiKey: 'test-api-key-123',
+      baseURL: 'http://test-host:11434',
+    });
+
+    expect(provider).toBeDefined();
+    expect(typeof provider).toBe('function');
+    const configs = getCapturedConfigs();
+    expect(configs.length).toBeGreaterThan(0);
+    const config = configs.at(-1);
+    expect(config).toBeDefined();
+    expect(config?.headers).toBeDefined();
+    const headers = config?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-api-key-123');
+  });
+
+  it('should not override existing Authorization header', () => {
+    const provider = createOllama({
+      apiKey: 'test-api-key-123',
+      headers: {
+        Authorization: 'Bearer existing-key',
+      },
+      baseURL: 'http://test-host:11434',
+    });
+
+    expect(provider).toBeDefined();
+    expect(typeof provider).toBe('function');
+    const configs = getCapturedConfigs();
+    expect(configs.length).toBeGreaterThan(0);
+    const config = configs.at(-1);
+    expect(config).toBeDefined();
+    expect(config?.headers).toBeDefined();
+    const headers = config?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer existing-key');
+  });
+
+  it('should handle Headers instance correctly', () => {
+    // Check if Headers is available (Node.js 18+)
+    if (typeof Headers === 'undefined') {
+      // Skip test if Headers is not available
+      return;
+    }
+
+    const headersInstance = new Headers();
+    headersInstance.set('X-Custom', 'custom-value');
+
+    const provider = createOllama({
+      apiKey: 'test-api-key-456',
+      headers: headersInstance,
+      baseURL: 'http://test-host:11434',
+    });
+
+    expect(provider).toBeDefined();
+    const configs = getCapturedConfigs();
+    expect(configs.length).toBeGreaterThan(0);
+    const config = configs.at(-1);
+    expect(config).toBeDefined();
+
+    // Headers should be normalized to a plain object by normalizeHeaders
+    expect(config?.headers).toBeDefined();
+
+    // After normalization, headers should be a plain object (not Headers instance or array)
+    const headers = config?.headers;
+    expect(headers).not.toBeInstanceOf(Headers);
+    expect(Array.isArray(headers)).toBe(false);
+
+    // Verify as plain object
+    // Note: Headers API lowercases all header names, and our normalizeHeaders
+    // adds Authorization with capital A, so we check for both cases
+    const plainHeaders = headers as Record<string, string>;
+    expect(plainHeaders.Authorization).toBe('Bearer test-api-key-456');
+    // Headers API stores keys in lowercase
+    expect(plainHeaders['x-custom']).toBe('custom-value');
+  });
+
+  it('should handle array headers correctly', () => {
+    const arrayHeaders: [string, string][] = [
+      ['X-Custom', 'custom-value'],
+      ['X-Another', 'another-value'],
+    ];
+
+    const provider = createOllama({
+      apiKey: 'test-api-key-789',
+      headers: arrayHeaders,
+      baseURL: 'http://test-host:11434',
+    });
+
+    expect(provider).toBeDefined();
+    const configs = getCapturedConfigs();
+    expect(configs.length).toBeGreaterThan(0);
+    const config = configs.at(-1);
+    expect(config).toBeDefined();
+    expect(config?.headers).toBeDefined();
+    const headers = config?.headers as Record<string, string>;
+    expect(headers['X-Custom']).toBe('custom-value');
+    expect(headers['X-Another']).toBe('another-value');
+    expect(headers.Authorization).toBe('Bearer test-api-key-789');
   });
 });

--- a/packages/ai-sdk-ollama/src/provider.ts
+++ b/packages/ai-sdk-ollama/src/provider.ts
@@ -52,6 +52,12 @@ export interface OllamaProviderSettings extends Pick<Config, 'headers' | 'fetch'
   baseURL?: string;
 
   /**
+   * Ollama API key for authentication with cloud services.
+   * The API key will be set as Authorization: Bearer {apiKey} header.
+   */
+  apiKey?: string;
+
+  /**
    * Existing Ollama client instance to use instead of creating a new one.
    * When provided, baseURL, headers, and fetch are ignored.
    */
@@ -226,18 +232,76 @@ export interface OllamaEmbeddingProviderOptions extends OllamaProviderOptions {
 }
 
 /**
+ * Type guard to check if an object is Headers-like (has entries method)
+ */
+function isHeadersLike(
+  obj: unknown,
+): obj is { entries: () => IterableIterator<[string, string]> } {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'entries' in obj &&
+    typeof (obj as { entries: unknown }).entries === 'function'
+  );
+}
+
+/**
+ * Normalize HeadersInit to a plain object for safe merging
+ */
+function normalizeHeaders(
+  headers: Record<string, string> | Headers | [string, string][] | undefined,
+): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+
+  // If it's an array of [key, value] tuples, convert first
+  if (Array.isArray(headers)) {
+    const result: Record<string, string> = {};
+    for (const [key, value] of headers) {
+      result[key] = value;
+    }
+    return result;
+  }
+
+  // If it's a Headers instance (check by method presence, not instanceof for cross-context compatibility)
+  if (isHeadersLike(headers)) {
+    const result: Record<string, string> = {};
+    for (const [key, value] of headers.entries()) {
+      result[key] = value;
+    }
+    return result;
+  }
+
+  // If it's already a plain object, return it
+  if (typeof headers === 'object') {
+    return headers as Record<string, string>;
+  }
+
+  return {};
+}
+
+/**
  * Create an Ollama provider instance
  */
 export function createOllama(
   options: OllamaProviderSettings = {},
 ): OllamaProvider {
+  // Normalize headers to a plain object for safe merging
+  const normalizedHeaders = normalizeHeaders(options.headers);
+
+  // Add Authorization header if apiKey is provided and not already set
+  if (options.apiKey && !normalizedHeaders.Authorization && !normalizedHeaders.authorization) {
+    normalizedHeaders.Authorization = `Bearer ${options.apiKey}`;
+  }
+
   // Use existing client or create new one
   const client =
     options.client ||
     new Ollama({
       host: options.baseURL,
       fetch: options.fetch,
-      headers: options.headers,
+      headers: Object.keys(normalizedHeaders).length > 0 ? normalizedHeaders : undefined,
     });
 
   const createChatModel = (


### PR DESCRIPTION
- Added a new section in README.md for API Key Configuration, detailing how to explicitly pass the API key when creating an Ollama instance.
- Implemented header normalization in provider.ts to ensure safe merging of headers, including the addition of the Authorization header when an API key is provided.
- Updated provider tests to verify correct handling of API keys and headers, ensuring that existing Authorization headers are not overridden.