### PR TITLE
fix(chat-language-model): ensure consistent reasoning event IDs

### DIFF
--- a/packages/ai-sdk-ollama/src/models/chat-language-model.test.ts
+++ b/packages/ai-sdk-ollama/src/models/chat-language-model.test.ts
@@ -848,6 +848,16 @@ describe('OllamaChatLanguageModel', () => {
         'Let me think about this step by step.',
       );
       expect(reasoningEnd).toBeDefined();
+
+      // Verify that all reasoning events use the same ID
+      // This is critical for AI SDK to properly aggregate reasoning content
+      expect(reasoningStart?.id).toBeDefined();
+      expect(reasoningDelta?.id).toBeDefined();
+      expect(reasoningEnd?.id).toBeDefined();
+      expect(reasoningStart?.id).toBe(reasoningDelta?.id);
+      expect(reasoningDelta?.id).toBe(reasoningEnd?.id);
+      expect(reasoningStart?.id).toBe(reasoningEnd?.id);
+
       // Final text may be emitted on the done chunk; accept either behavior
       // If text was emitted, it should match our final chunk content
       if (textDelta) {

--- a/packages/ai-sdk-ollama/src/models/chat-language-model.ts
+++ b/packages/ai-sdk-ollama/src/models/chat-language-model.ts
@@ -1419,20 +1419,21 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
             if (chunk.message.thinking && reasoningEnabled) {
               // For reasoning, we'll emit it as a single reasoning content
               // since Ollama doesn't stream reasoning in chunks
+              const reasoningId = crypto.randomUUID();
               controller.enqueue({
                 type: 'reasoning-start',
-                id: crypto.randomUUID(),
+                id: reasoningId,
               });
 
               controller.enqueue({
                 type: 'reasoning-delta',
-                id: crypto.randomUUID(),
+                id: reasoningId,
                 delta: chunk.message.thinking,
               });
 
               controller.enqueue({
                 type: 'reasoning-end',
-                id: crypto.randomUUID(),
+                id: reasoningId,
               });
             }
 


### PR DESCRIPTION
Updated the reasoning event handling in the OllamaChatLanguageModel to use a single UUID for all reasoning events (start, delta, end). This change is crucial for the AI SDK to properly aggregate reasoning content.

by issues https://github.com/jagreehal/ai-sdk-ollama/issues/344 