### PR TITLE
chore(deps): update dependencies and improve JSON handling

### DIFF
--- a/.changeset/bumpy-tips-serve.md
+++ b/.changeset/bumpy-tips-serve.md
@@ -1,0 +1,12 @@
+---
+'ai-sdk-ollama': minor
+---
+
+Update examples, tests, and documentation to use `generateText` with `Output.object()` instead of deprecated `generateObject`.
+
+- Updated all example files to use the new API pattern
+- Updated integration tests to use `generateText` with `Output.object()`
+- Updated documentation and README files to reflect the new API
+- Updated code comments to reference the new API
+
+This change aligns with AI SDK v6 recommendations. The deprecated `generateObject` function still works but is no longer shown in examples or documentation.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ npx tsx examples/node/src/web-search-ai-sdk-ollama.ts error    # Run error handl
 
 ```typescript
 import { ollama } from 'ai-sdk-ollama';
-import { generateText, streamText, generateObject, streamObject, embed, tool } from 'ai';
+import { generateText, streamText, Output, embed, tool } from 'ai';
 import { z } from 'zod';
 
 // Text generation - works exactly like OpenAI, Anthropic, etc.
@@ -184,22 +184,26 @@ const { textStream } = await streamText({
 });
 
 // Structured object generation
-const { object } = await generateObject({
+const { output } = await generateText({
   model: ollama('llama3.2'),
-  schema: z.object({
-    name: z.string(),
-    age: z.number(),
-    interests: z.array(z.string()),
+  output: Output.object({
+    schema: z.object({
+      name: z.string(),
+      age: z.number(),
+      interests: z.array(z.string()),
+    }),
   }),
   prompt: 'Generate a random person profile',
 });
 
 // Streaming structured objects
-const { objectStream } = await streamObject({
+const { partialOutputStream } = await streamText({
   model: ollama('llama3.2'),
-  schema: z.object({
-    step: z.string(),
-    result: z.string(),
+  output: Output.object({
+    schema: z.object({
+      step: z.string(),
+      result: z.string(),
+    }),
   }),
   prompt: 'Break down the process of making coffee',
 });
@@ -271,16 +275,18 @@ const { text } = await generateText({
 ### Structured Object Generation
 
 ```typescript
-import { generateObject } from 'ai';
+import { generateText, Output } from 'ai';
 import { z } from 'zod';
 
 // Auto-detection: structured outputs enabled automatically
-const { object } = await generateObject({
+const { output } = await generateText({
   model: ollama('llama3.2'),
-  schema: z.object({
-    name: z.string(),
-    age: z.number(),
-    interests: z.array(z.string()),
+  output: Output.object({
+    schema: z.object({
+      name: z.string(),
+      age: z.number(),
+      interests: z.array(z.string()),
+    }),
   }),
   prompt: 'Generate a random person profile',
 });

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -16,7 +16,7 @@
     "quality": "pnpm type-check && pnpm build"
   },
   "dependencies": {
-    "@ai-sdk/react": "^3.0.44",
+    "@ai-sdk/react": "^3.0.46",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -28,7 +28,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@tailwindcss/vite": "^4.1.18",
-    "ai": "^6.0.42",
+    "ai": "^6.0.44",
     "ai-sdk-ollama": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@ai-sdk/mcp": "^1.0.11",
-    "ai": "^6.0.42",
+    "ai": "^6.0.44",
     "ai-sdk-ollama": "workspace:*",
     "dotenv": "^17.2.3",
     "ollama": "^0.6.3",

--- a/examples/node/src/README.md
+++ b/examples/node/src/README.md
@@ -62,6 +62,11 @@ This directory contains comprehensive examples demonstrating the enhanced Ollama
     - Basic reasoning example
     - Run: `npx tsx src/reasoning-example-simple.ts`
 
+14. **`quoted-json-example.ts`** - Quoted JSON Fix Example
+    - Demonstrates the fix for JSON wrapped in quotes or markdown
+    - Shows how string values are preserved during JSON repair
+    - Run: `npx tsx src/quoted-json-example.ts`
+
 ## Key Features Demonstrated
 
 ### Enhanced Ollama Provider Features
@@ -74,9 +79,9 @@ This directory contains comprehensive examples demonstrating the enhanced Ollama
 ### Standard AI SDK Functions
 All examples use the standard AI SDK functions with the enhanced Ollama provider:
 - `generateText` - Text generation with tools
-- `generateObject` - Structured object generation
+- `generateText` with `Output.object()` - Structured object generation
 - `streamText` - Real-time text streaming
-- `streamObject` - Real-time object streaming
+- `streamText` with `Output.object()` - Real-time object streaming
 - `embed` - Text embeddings
 
 ## Usage Patterns
@@ -107,17 +112,17 @@ const result = await generateText({
 ### For Object Generation
 ```typescript
 import { ollama } from 'ai-sdk-ollama';
-import { generateObject } from 'ai';
+import { generateText, Output } from 'ai';
 import { z } from 'zod';
 
 const schema = z.object({
   // your schema
 });
 
-const result = await generateObject({
+const result = await generateText({
   model: ollama('llama3.2'),
   prompt: 'Your prompt here',
-  schema,
+  output: Output.object({ schema }),
 });
 ```
 

--- a/examples/node/src/quoted-json-example.ts
+++ b/examples/node/src/quoted-json-example.ts
@@ -1,0 +1,146 @@
+import { generateText, Output } from 'ai';
+import { ollama } from 'ai-sdk-ollama';
+import { z } from 'zod';
+
+/**
+ * Example demonstrating the fix for JSON wrapped in quotes
+ *
+ * This example shows how the provider now correctly handles cases where
+ * the model returns JSON wrapped in quotes (e.g., "{\"key\": \"value\"}")
+ * or in markdown code blocks, which was causing schema validation failures.
+ *
+ * Issue: https://github.com/jagreehal/ai-sdk-ollama/issues/440
+ */
+
+async function main() {
+  console.log('🔧 Quoted JSON Fix Example\n');
+  console.log(
+    'This example demonstrates the fix for JSON wrapped in quotes or markdown.\n',
+  );
+
+  try {
+    // Example 1: Basic object generation
+    // The model might return JSON wrapped in quotes, which is now handled correctly
+    console.log('📝 Example 1: Basic object generation');
+    console.log(
+      '   (Handles JSON wrapped in quotes: "{\\"key\\": \\"value\\"}")\n',
+    );
+
+    const result1 = await generateText({
+      model: ollama('llama3.2', {
+        structuredOutputs: true,
+      }),
+      output: Output.object({
+        schema: z.object({
+          name: z.string(),
+          age: z.number(),
+          city: z.string(),
+        }),
+      }),
+      prompt:
+        'Generate a person profile: name "Alice", age 28, city "San Francisco". Return as JSON.',
+    });
+
+    console.log('✅ Generated object:', JSON.stringify(result1.output, null, 2));
+    console.log();
+
+    // Example 2: Complex nested object
+    // Demonstrates that the fix works with nested structures
+    console.log('📝 Example 2: Complex nested object');
+    console.log('   (Handles nested JSON wrapped in quotes)\n');
+
+    const result2 = await generateText({
+      model: ollama('llama3.2', {
+        structuredOutputs: true,
+      }),
+      output: Output.object({
+        schema: z.object({
+          recipe: z.object({
+            name: z.string(),
+            ingredients: z.array(
+              z.object({
+                name: z.string(),
+                amount: z.string(),
+              }),
+            ),
+            steps: z.array(z.string()),
+          }),
+        }),
+      }),
+      prompt:
+        'Generate a simple pasta recipe. Return the recipe as a JSON object.',
+    });
+
+    console.log('✅ Generated recipe:', JSON.stringify(result2.output, null, 2));
+    console.log();
+
+    // Example 3: Array of objects
+    // Shows that arrays are also handled correctly
+    console.log('📝 Example 3: Array of objects');
+    console.log('   (Handles arrays wrapped in quotes)\n');
+
+    const result3 = await generateText({
+      model: ollama('llama3.2', {
+        structuredOutputs: true,
+      }),
+      output: Output.object({
+        schema: z.object({
+          items: z.array(
+            z.object({
+              id: z.number(),
+              name: z.string(),
+              price: z.number(),
+            }),
+          ),
+        }),
+      }),
+      prompt:
+        'Generate a list of 3 products with id, name, and price. Return as JSON array.',
+    });
+
+    console.log('✅ Generated items:', JSON.stringify(result3.output, null, 2));
+    console.log();
+
+    // Example 4: String values that look like JSON
+    // Demonstrates that legitimate string values are not corrupted
+    console.log('📝 Example 4: String values preserved');
+    console.log(
+      '   (String values like "True", "None", "False" are preserved)\n',
+    );
+
+    const result4 = await generateText({
+      model: ollama('llama3.2', {
+        structuredOutputs: true,
+      }),
+      output: Output.object({
+        schema: z.object({
+          status: z.string(),
+          value: z.string(),
+          note: z.string(),
+        }),
+      }),
+      prompt:
+        'Generate an object with status="True", value="None", and note="/* keep this */". Return as JSON.',
+    });
+
+    console.log('✅ Generated object:', JSON.stringify(result4.output, null, 2));
+    console.log('   Note: String values should be preserved, not converted.\n');
+
+    console.log('✨ All examples completed successfully!');
+    console.log(
+      '\n💡 The fix ensures that:\n' +
+        '   - JSON wrapped in quotes is correctly parsed\n' +
+        '   - JSON in markdown code blocks is extracted\n' +
+        '   - String values are not corrupted during repair\n' +
+        '   - Non-object schemas (string, number, array) are handled correctly',
+    );
+  } catch (error) {
+    console.error('❌ Error:', error);
+    if (error instanceof Error) {
+      console.error('   Message:', error.message);
+    }
+    process.exit(1);
+  }
+}
+
+main().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-unicorn": "^62.0.0",
-    "prettier": "^3.8.0",
+    "prettier": "^3.8.1",
     "turbo": "^2.7.5",
     "typescript-eslint": "^8.53.1"
   },

--- a/packages/ai-sdk-ollama/README.md
+++ b/packages/ai-sdk-ollama/README.md
@@ -754,29 +754,33 @@ const { text } = await generateText({
 ### Structured Output
 
 ```typescript
-import { generateObject } from 'ai';
+import { generateText, Output } from 'ai';
 import { z } from 'zod';
 
 // Auto-detection: structuredOutputs is automatically enabled for object generation
-const { object } = await generateObject({
+const { output } = await generateText({
   model: ollama('llama3.2'), // No need to set structuredOutputs: true
-  schema: z.object({
-    name: z.string(),
-    age: z.number(),
-    interests: z.array(z.string()),
+  output: Output.object({
+    schema: z.object({
+      name: z.string(),
+      age: z.number(),
+      interests: z.array(z.string()),
+    }),
   }),
   prompt: 'Generate a random person profile',
 });
 
-console.log(object);
+console.log(output);
 // { name: "Alice", age: 28, interests: ["reading", "hiking"] }
 
 // Explicit setting still works
-const { object: explicitObject } = await generateObject({
+const { output: explicitOutput } = await generateText({
   model: ollama('llama3.2', { structuredOutputs: true }), // Explicit
-  schema: z.object({
-    name: z.string(),
-    age: z.number(),
+  output: Output.object({
+    schema: z.object({
+      name: z.string(),
+      age: z.number(),
+    }),
   }),
   prompt: 'Generate a person',
 });
@@ -786,20 +790,22 @@ const { object: explicitObject } = await generateObject({
 
 The provider automatically detects when structured outputs are needed:
 
-- **Object Generation**: `generateObject` and `streamObject` automatically enable `structuredOutputs: true`
+- **Object Generation**: `generateText` with `Output.object()` and `streamText` with `Output.object()` automatically enable `structuredOutputs: true`
 - **Text Generation**: `generateText` and `streamText` require explicit `structuredOutputs: true` for JSON output
 - **Backward Compatibility**: Explicit settings are respected, with warnings when overridden
 - **No Breaking Changes**: Existing code continues to work as expected
 
 ```typescript
 import { ollama } from 'ai-sdk-ollama';
-import { generateObject, generateText } from 'ai';
+import { generateText, Output } from 'ai';
 import { z } from 'zod';
 
 // This works without explicit structuredOutputs: true
-const { object } = await generateObject({
+const { output } = await generateText({
   model: ollama('llama3.2'),
-  schema: z.object({ name: z.string() }),
+  output: Output.object({
+    schema: z.object({ name: z.string() }),
+  }),
   prompt: 'Generate a name',
 });
 
@@ -818,16 +824,18 @@ The provider includes automatic JSON repair that handles 14+ types of common JSO
 
 ````typescript
 import { ollama } from 'ai-sdk-ollama';
-import { generateObject } from 'ai';
+import { generateText, Output } from 'ai';
 import { z } from 'zod';
 
 // JSON repair is enabled by default for all object generation
-const { object } = await generateObject({
+const { output } = await generateText({
   model: ollama('llama3.2'),
-  schema: z.object({
-    name: z.string(),
-    email: z.string().email(),
-    age: z.number(),
+  output: Output.object({
+    schema: z.object({
+      name: z.string(),
+      email: z.string().email(),
+      age: z.number(),
+    }),
   }),
   prompt: 'Generate a person profile',
   // reliableObjectGeneration: true is the default
@@ -852,16 +860,18 @@ const { object } = await generateObject({
 
 ```typescript
 // Disable all reliability features (not recommended)
-const { object } = await generateObject({
+const { output } = await generateText({
   model: ollama('llama3.2', {
     reliableObjectGeneration: false, // Everything off
   }),
-  schema: z.object({ message: z.string() }),
+  output: Output.object({
+    schema: z.object({ message: z.string() }),
+  }),
   prompt: 'Generate a message',
 });
 
 // Fine-grained control: disable only repair, keep retries
-const { object: withRetries } = await generateObject({
+const { output: withRetries } = await generateText({
   model: ollama('llama3.2', {
     reliableObjectGeneration: true,
     objectGenerationOptions: {
@@ -869,12 +879,14 @@ const { object: withRetries } = await generateObject({
       maxRetries: 3, // But keep retries
     },
   }),
-  schema: z.object({ message: z.string() }),
+  output: Output.object({
+    schema: z.object({ message: z.string() }),
+  }),
   prompt: 'Generate a message',
 });
 
 // Custom repair function (advanced)
-const { object: custom } = await generateObject({
+const { output: custom } = await generateText({
   model: ollama('llama3.2', {
     objectGenerationOptions: {
       repairText: async ({ text, error }) => {
@@ -883,7 +895,9 @@ const { object: custom } = await generateObject({
       },
     },
   }),
-  schema: z.object({ message: z.string() }),
+  output: Output.object({
+    schema: z.object({ message: z.string() }),
+  }),
   prompt: 'Generate a message',
 });
 ```

--- a/packages/ai-sdk-ollama/package.json
+++ b/packages/ai-sdk-ollama/package.json
@@ -89,7 +89,7 @@
     "ollama": "^0.6.3"
   },
   "peerDependencies": {
-    "ai": "^6.0.27"
+    "ai": "^6.0.44"
   },
   "devDependencies": {
     "@ai-sdk/test-server": "^1.0.1",
@@ -103,13 +103,13 @@
     "@typescript-eslint/parser": "^8.53.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-unicorn": "^62.0.0",
-    "prettier": "^3.8.0",
+    "prettier": "^3.8.1",
     "rimraf": "^6.1.2",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.53.1",
     "vite-tsconfig-paths": "^6.0.4",
-    "vitest": "^4.0.16",
+    "vitest": "^4.0.17",
     "zod": "^4.3.5"
   },
   "engines": {

--- a/packages/ai-sdk-ollama/src/integration-tests/README.md
+++ b/packages/ai-sdk-ollama/src/integration-tests/README.md
@@ -302,7 +302,7 @@ ollama serve
 
 The integration tests comprehensively cover:
 
-- ✅ All AI SDK core functions (`generateText`, `streamText`, `generateObject`, `streamObject`)
+- ✅ All AI SDK core functions (`generateText`, `streamText`, `generateText` with `Output.object()`, `streamText` with `Output.object()`)
 - ✅ Embedding functions (`embed`, `embedMany`, `cosineSimilarity`)
 - ✅ Advanced features (tool calling, multi-step, JSON schema, multimodal)
 - ✅ Ollama-specific parameters and configurations

--- a/packages/ai-sdk-ollama/src/integration-tests/auto-detection.int.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/auto-detection.int.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateObject, streamObject, generateText } from 'ai';
+import { generateText, streamText, Output } from 'ai';
 import { ollama } from '../index';
 import { z } from 'zod';
 
@@ -7,36 +7,40 @@ import { z } from 'zod';
 describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)(
   'Auto-Detection Integration Tests',
   () => {
-    it('should auto-detect structuredOutputs for generateObject without explicit setting', async () => {
-      const result = await generateObject({
+    it('should auto-detect structuredOutputs for generateText with Output.object without explicit setting', async () => {
+      const result = await generateText({
         model: ollama('llama3.2'), // No structuredOutputs: true
         prompt: 'Generate a simple person with name Alice, age 25, city London',
-        schema: z.object({
-          name: z.string(),
-          age: z.number(),
-          city: z.string(),
+        output: Output.object({
+          schema: z.object({
+            name: z.string(),
+            age: z.number(),
+            city: z.string(),
+          }),
         }),
       });
 
-      expect(result.object).toBeDefined();
-      expect(result.object.name).toBeTruthy();
-      expect(typeof result.object.age).toBe('number');
-      expect(result.object.city).toBeTruthy();
+      expect(result.output).toBeDefined();
+      expect(result.output.name).toBeTruthy();
+      expect(typeof result.output.age).toBe('number');
+      expect(result.output.city).toBeTruthy();
     });
 
-    it('should auto-detect structuredOutputs for streamObject without explicit setting', async () => {
-      const result = streamObject({
+    it('should auto-detect structuredOutputs for streamText with Output.object without explicit setting', async () => {
+      const result = streamText({
         model: ollama('llama3.2'), // No structuredOutputs: true
         prompt: 'Generate a simple person with name Bob, age 30, city Paris',
-        schema: z.object({
-          name: z.string(),
-          age: z.number(),
-          city: z.string(),
+        output: Output.object({
+          schema: z.object({
+            name: z.string(),
+            age: z.number(),
+            city: z.string(),
+          }),
         }),
       });
 
       const partialObjects: Record<string, unknown>[] = [];
-      for await (const partialObject of result.partialObjectStream) {
+      for await (const partialObject of result.partialOutputStream) {
         partialObjects.push(partialObject);
       }
 
@@ -59,21 +63,23 @@ describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)(
     });
 
     it('should still work with explicit structuredOutputs: true', async () => {
-      const result = await generateObject({
+      const result = await generateText({
         model: ollama('llama3.2', { structuredOutputs: true }), // Explicit
         prompt:
           'Generate a simple person with name Charlie, age 35, city Berlin',
-        schema: z.object({
-          name: z.string(),
-          age: z.number(),
-          city: z.string(),
+        output: Output.object({
+          schema: z.object({
+            name: z.string(),
+            age: z.number(),
+            city: z.string(),
+          }),
         }),
       });
 
-      expect(result.object).toBeDefined();
-      expect(result.object.name).toBeTruthy();
-      expect(typeof result.object.age).toBe('number');
-      expect(result.object.city).toBeTruthy();
+      expect(result.output).toBeDefined();
+      expect(result.output.name).toBeTruthy();
+      expect(typeof result.output.age).toBe('number');
+      expect(result.output.city).toBeTruthy();
     });
 
     it('should not auto-detect for regular generateText calls', async () => {
@@ -90,43 +96,47 @@ describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)(
 
     it('should work with explicit structuredOutputs: false for object generation', async () => {
       // This should still work because auto-detection overrides explicit false
-      const result = await generateObject({
+      const result = await generateText({
         model: ollama('llama3.2', { structuredOutputs: false }), // Explicit false
         prompt: 'Generate a simple person with name David, age 40, city Rome',
-        schema: z.object({
-          name: z.string(),
-          age: z.number(),
-          city: z.string(),
-        }),
-      });
-
-      expect(result.object).toBeDefined();
-      expect(result.object.name).toBeTruthy();
-      expect(typeof result.object.age).toBe('number');
-      expect(result.object.city).toBeTruthy();
-    });
-
-    it('should handle complex schemas with auto-detection', async () => {
-      const result = await generateObject({
-        model: ollama('llama3.2'), // No structuredOutputs: true
-        prompt:
-          'Generate a simple person with name, age, and a list of 3 hobbies',
-        maxOutputTokens: 300, // More tokens for complex schema
-        schema: z.object({
-          person: z.object({
+        output: Output.object({
+          schema: z.object({
             name: z.string(),
             age: z.number(),
-            hobbies: z.array(z.string()),
+            city: z.string(),
           }),
         }),
       });
 
-      expect(result.object).toBeDefined();
-      expect(result.object.person).toBeDefined();
-      expect(result.object.person.name).toBeTruthy();
-      expect(typeof result.object.person.age).toBe('number');
-      expect(Array.isArray(result.object.person.hobbies)).toBe(true);
-      expect(result.object.person.hobbies.length).toBe(3);
+      expect(result.output).toBeDefined();
+      expect(result.output.name).toBeTruthy();
+      expect(typeof result.output.age).toBe('number');
+      expect(result.output.city).toBeTruthy();
+    });
+
+    it('should handle complex schemas with auto-detection', async () => {
+      const result = await generateText({
+        model: ollama('llama3.2'), // No structuredOutputs: true
+        prompt:
+          'Generate a simple person with name, age, and a list of 3 hobbies',
+        maxOutputTokens: 300, // More tokens for complex schema
+        output: Output.object({
+          schema: z.object({
+            person: z.object({
+              name: z.string(),
+              age: z.number(),
+              hobbies: z.array(z.string()),
+            }),
+          }),
+        }),
+      });
+
+      expect(result.output).toBeDefined();
+      expect(result.output.person).toBeDefined();
+      expect(result.output.person.name).toBeTruthy();
+      expect(typeof result.output.person.age).toBe('number');
+      expect(Array.isArray(result.output.person.hobbies)).toBe(true);
+      expect(result.output.person.hobbies.length).toBe(3);
     }, 10_000); // 10 second timeout
   },
 );

--- a/packages/ai-sdk-ollama/src/integration-tests/auto-detection.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/auto-detection.test.ts
@@ -1,40 +1,44 @@
 import { describe, it, expect } from 'vitest';
-import { generateObject, streamObject, generateText } from 'ai';
+import { generateText, streamText, Output } from 'ai';
 import { ollama } from '../index';
 import { z } from 'zod';
 
 // Integration test for auto-detection of structuredOutputs
 describe('Auto-Detection Integration Tests', () => {
-  it('should auto-detect structuredOutputs for generateObject without explicit setting', async () => {
-    const result = await generateObject({
+  it('should auto-detect structuredOutputs for generateText with Output.object without explicit setting', async () => {
+    const result = await generateText({
       model: ollama('llama3.2'), // No structuredOutputs: true
       prompt: 'Generate a simple person with name Alice, age 25, city London',
-      schema: z.object({
-        name: z.string(),
-        age: z.number(),
-        city: z.string(),
+      output: Output.object({
+        schema: z.object({
+          name: z.string(),
+          age: z.number(),
+          city: z.string(),
+        }),
       }),
     });
 
-    expect(result.object).toBeDefined();
-    expect(result.object.name).toBeTruthy();
-    expect(typeof result.object.age).toBe('number');
-    expect(result.object.city).toBeTruthy();
+    expect(result.output).toBeDefined();
+    expect(result.output.name).toBeTruthy();
+    expect(typeof result.output.age).toBe('number');
+    expect(result.output.city).toBeTruthy();
   });
 
-  it('should auto-detect structuredOutputs for streamObject without explicit setting', async () => {
-    const result = streamObject({
+  it('should auto-detect structuredOutputs for streamText with Output.object without explicit setting', async () => {
+    const result = streamText({
       model: ollama('llama3.2'), // No structuredOutputs: true
       prompt: 'Generate a simple person with name Bob, age 30, city Paris',
-      schema: z.object({
-        name: z.string(),
-        age: z.number(),
-        city: z.string(),
+      output: Output.object({
+        schema: z.object({
+          name: z.string(),
+          age: z.number(),
+          city: z.string(),
+        }),
       }),
     });
 
     const partialObjects: Record<string, unknown>[] = [];
-    for await (const partialObject of result.partialObjectStream) {
+    for await (const partialObject of result.partialOutputStream) {
       partialObjects.push(partialObject);
     }
 
@@ -51,20 +55,22 @@ describe('Auto-Detection Integration Tests', () => {
   });
 
   it('should still work with explicit structuredOutputs: true', async () => {
-    const result = await generateObject({
+    const result = await generateText({
       model: ollama('llama3.2', { structuredOutputs: true }), // Explicit
       prompt: 'Generate a simple person with name Charlie, age 35, city Berlin',
-      schema: z.object({
-        name: z.string(),
-        age: z.number(),
-        city: z.string(),
+      output: Output.object({
+        schema: z.object({
+          name: z.string(),
+          age: z.number(),
+          city: z.string(),
+        }),
       }),
     });
 
-    expect(result.object).toBeDefined();
-    expect(result.object.name).toBeTruthy();
-    expect(typeof result.object.age).toBe('number');
-    expect(result.object.city).toBeTruthy();
+    expect(result.output).toBeDefined();
+    expect(result.output.name).toBeTruthy();
+    expect(typeof result.output.age).toBe('number');
+    expect(result.output.city).toBeTruthy();
   });
 
   it('should not auto-detect for regular generateText calls', async () => {
@@ -81,48 +87,52 @@ describe('Auto-Detection Integration Tests', () => {
 
   it('should work with explicit structuredOutputs: false for object generation', async () => {
     // This should still work because auto-detection overrides explicit false
-    const result = await generateObject({
+    const result = await generateText({
       model: ollama('llama3.2', { structuredOutputs: false }), // Explicit false
       prompt: 'Generate a simple person with name David, age 40, city Rome',
-      schema: z.object({
-        name: z.string(),
-        age: z.number(),
-        city: z.string(),
-      }),
-    });
-
-    expect(result.object).toBeDefined();
-    expect(result.object.name).toBeTruthy();
-    expect(typeof result.object.age).toBe('number');
-    expect(result.object.city).toBeTruthy();
-  });
-
-  it('should handle complex schemas with auto-detection', async () => {
-    const result = await generateObject({
-      model: ollama('llama3.2'), // No structuredOutputs: true
-      prompt:
-        'Generate a simple person with name, age, and a list of 3 hobbies',
-      maxOutputTokens: 300, // More tokens for complex schema
-      schema: z.object({
-        person: z.object({
+      output: Output.object({
+        schema: z.object({
           name: z.string(),
           age: z.number(),
-          hobbies: z.array(z.string()),
+          city: z.string(),
         }),
       }),
     });
 
-    expect(result.object).toBeDefined();
-    expect(result.object.person).toBeDefined();
-    expect(result.object.person.name).toBeTruthy();
-    expect(typeof result.object.person.age).toBe('number');
-    expect(Array.isArray(result.object.person.hobbies)).toBe(true);
-    if (result.object.person.hobbies.length !== 3) {
+    expect(result.output).toBeDefined();
+    expect(result.output.name).toBeTruthy();
+    expect(typeof result.output.age).toBe('number');
+    expect(result.output.city).toBeTruthy();
+  });
+
+  it('should handle complex schemas with auto-detection', async () => {
+    const result = await generateText({
+      model: ollama('llama3.2'), // No structuredOutputs: true
+      prompt:
+        'Generate a simple person with name, age, and a list of 3 hobbies',
+      maxOutputTokens: 300, // More tokens for complex schema
+      output: Output.object({
+        schema: z.object({
+          person: z.object({
+            name: z.string(),
+            age: z.number(),
+            hobbies: z.array(z.string()),
+          }),
+        }),
+      }),
+    });
+
+    expect(result.output).toBeDefined();
+    expect(result.output.person).toBeDefined();
+    expect(result.output.person.name).toBeTruthy();
+    expect(typeof result.output.person.age).toBe('number');
+    expect(Array.isArray(result.output.person.hobbies)).toBe(true);
+    if (result.output.person.hobbies.length !== 3) {
       console.warn(
         'Warning: Model did not return exactly 3 hobbies. Got:',
-        result.object.person.hobbies.length,
+        result.output.person.hobbies.length,
       );
     }
-    expect(result.object.person.hobbies.length).toBeGreaterThan(0);
+    expect(result.output.person.hobbies.length).toBeGreaterThan(0);
   }, 30_000); // 30 second timeout
 });

--- a/packages/ai-sdk-ollama/src/integration-tests/generate-object.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/generate-object.test.ts
@@ -1,38 +1,40 @@
 import { describe, it, expect } from 'vitest';
-import { generateObject } from 'ai';
+import { generateText, Output } from 'ai';
 import { ollama } from '../index';
 import { z } from 'zod';
 
 // Integration test for object generation
 describe('Generate Object Integration Tests', () => {
   it('should generate structured object with recipe schema', async () => {
-    const result = await generateObject({
+    const result = await generateText({
       model: ollama('llama3.2', { structuredOutputs: true }),
       prompt: 'Generate a lasagna recipe.',
-      schema: z.object({
-        recipe: z.object({
-          ingredients: z.array(
-            z.object({
-              amount: z.string(),
-              name: z.string(),
-            }),
-          ),
-          name: z.string(),
-          steps: z.array(z.string()),
+      output: Output.object({
+        schema: z.object({
+          recipe: z.object({
+            ingredients: z.array(
+              z.object({
+                amount: z.string(),
+                name: z.string(),
+              }),
+            ),
+            name: z.string(),
+            steps: z.array(z.string()),
+          }),
         }),
       }),
     });
 
-    expect(result.object).toBeDefined();
-    expect(result.object.recipe).toBeDefined();
-    expect(result.object.recipe.name).toBeTruthy();
-    expect(Array.isArray(result.object.recipe.ingredients)).toBe(true);
-    expect(Array.isArray(result.object.recipe.steps)).toBe(true);
-    expect(result.object.recipe.ingredients.length).toBeGreaterThan(0);
-    expect(result.object.recipe.steps.length).toBeGreaterThan(0);
+    expect(result.output).toBeDefined();
+    expect(result.output.recipe).toBeDefined();
+    expect(result.output.recipe.name).toBeTruthy();
+    expect(Array.isArray(result.output.recipe.ingredients)).toBe(true);
+    expect(Array.isArray(result.output.recipe.steps)).toBe(true);
+    expect(result.output.recipe.ingredients.length).toBeGreaterThan(0);
+    expect(result.output.recipe.steps.length).toBeGreaterThan(0);
 
     // Check ingredient structure
-    for (const ingredient of result.object.recipe.ingredients) {
+    for (const ingredient of result.output.recipe.ingredients) {
       expect(typeof ingredient.amount).toBe('string');
       expect(typeof ingredient.name).toBe('string');
       if (!ingredient.amount) {
@@ -48,41 +50,43 @@ describe('Generate Object Integration Tests', () => {
     }
 
     // Check steps structure
-    for (const step of result.object.recipe.steps) {
+    for (const step of result.output.recipe.steps) {
       expect(typeof step).toBe('string');
       expect(step.length).toBeGreaterThan(0);
     }
   });
 
   it('should generate array of objects', async () => {
-    const result = await generateObject({
+    const result = await generateText({
       model: ollama('llama3.2', { structuredOutputs: true }),
       prompt:
         'Generate 3 character descriptions for a fantasy role playing game.',
-      schema: z.object({
-        characters: z.array(
-          z.object({
-            class: z
-              .string()
-              .describe('Character class, e.g. warrior, mage, or thief.'),
-            description: z.string(),
-            name: z.string(),
-          }),
-        ),
+      output: Output.object({
+        schema: z.object({
+          characters: z.array(
+            z.object({
+              class: z
+                .string()
+                .describe('Character class, e.g. warrior, mage, or thief.'),
+              description: z.string(),
+              name: z.string(),
+            }),
+          ),
+        }),
       }),
     });
 
-    expect(result.object).toBeDefined();
-    expect(Array.isArray(result.object.characters)).toBe(true);
-    if (result.object.characters.length !== 3) {
+    expect(result.output).toBeDefined();
+    expect(Array.isArray(result.output.characters)).toBe(true);
+    if (result.output.characters.length !== 3) {
       console.warn(
         'Warning: Model did not return exactly 3 characters. Got:',
-        result.object.characters.length,
+        result.output.characters.length,
       );
     }
-    expect(result.object.characters.length).toBeGreaterThan(0);
+    expect(result.output.characters.length).toBeGreaterThan(0);
 
-    for (const character of result.object.characters) {
+    for (const character of result.output.characters) {
       expect(character.name).toBeTruthy();
       expect(character.class).toBeTruthy();
       expect(character.description).toBeTruthy();
@@ -93,59 +97,65 @@ describe('Generate Object Integration Tests', () => {
   });
 
   it('should generate simple object with basic types', async () => {
-    const result = await generateObject({
+    const result = await generateText({
       model: ollama('llama3.2', { structuredOutputs: true }),
       prompt: 'Generate a person with name John, age 30, living in New York',
-      schema: z.object({
-        name: z.string(),
-        age: z.number(),
-        city: z.string(),
+      output: Output.object({
+        schema: z.object({
+          name: z.string(),
+          age: z.number(),
+          city: z.string(),
+        }),
       }),
     });
 
-    expect(result.object).toBeDefined();
-    expect(result.object.name).toBeTruthy();
-    expect(typeof result.object.age).toBe('number');
-    expect(result.object.city).toBeTruthy();
-    expect(result.object.age).toBeGreaterThan(0);
+    expect(result.output).toBeDefined();
+    expect(result.output.name).toBeTruthy();
+    expect(typeof result.output.age).toBe('number');
+    expect(result.output.city).toBeTruthy();
+    expect(result.output.age).toBeGreaterThan(0);
   });
 
   it('should handle nested object structures', async () => {
-    const result = await generateObject({
+    const result = await generateText({
       model: ollama('llama3.2', { structuredOutputs: true }),
       prompt: 'Generate a book with title, author, and publication details',
-      schema: z.object({
-        book: z.object({
-          title: z.string(),
-          author: z.object({
-            name: z.string(),
-            country: z.string(),
-          }),
-          publication: z.object({
-            year: z.number(),
-            publisher: z.string(),
+      output: Output.object({
+        schema: z.object({
+          book: z.object({
+            title: z.string(),
+            author: z.object({
+              name: z.string(),
+              country: z.string(),
+            }),
+            publication: z.object({
+              year: z.number(),
+              publisher: z.string(),
+            }),
           }),
         }),
       }),
     });
 
-    expect(result.object).toBeDefined();
-    expect(result.object.book).toBeDefined();
-    expect(result.object.book.title).toBeTruthy();
-    expect(result.object.book.author).toBeDefined();
-    expect(result.object.book.author.name).toBeTruthy();
-    expect(result.object.book.author.country).toBeTruthy();
-    expect(result.object.book.publication).toBeDefined();
-    expect(typeof result.object.book.publication.year).toBe('number');
-    expect(result.object.book.publication.publisher).toBeTruthy();
+    expect(result.output).toBeDefined();
+    expect(result.output.book).toBeDefined();
+    expect(result.output.book.title).toBeTruthy();
+    expect(result.output.book.author).toBeDefined();
+    expect(result.output.book.author.name).toBeTruthy();
+    expect(result.output.book.author.country).toBeTruthy();
+    expect(result.output.book.publication).toBeDefined();
+    expect(typeof result.output.book.publication.year).toBe('number');
+    expect(result.output.book.publication.publisher).toBeTruthy();
   });
 
   it('should include usage and finish reason', async () => {
-    const result = await generateObject({
+    const result = await generateText({
       model: ollama('llama3.2', { structuredOutputs: true }),
       prompt: 'Generate a simple object with a message field',
-      schema: z.object({
-        message: z.string(),
+      output: Output.object({
+        schema: z.object({
+          message: z.string(),
+        }),
       }),
     });
 

--- a/packages/ai-sdk-ollama/src/integration-tests/gpt-oss-20b.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/gpt-oss-20b.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateText, generateObject, streamText } from 'ai';
+import { generateText, Output, streamText } from 'ai';
 import { z } from 'zod';
 import { ollama } from '../index';
 
@@ -100,20 +100,20 @@ describe('GPT-OSS:20B Model Integration Tests', () => {
     });
 
     try {
-      const result = await generateObject({
+      const result = await generateText({
         model: ollama(modelName, { structuredOutputs: true }),
-        schema,
+        output: Output.object({ schema }),
         prompt:
           'Generate a fictional person profile with name, age, and occupation',
       });
 
-      expect(result.object).toBeTruthy();
-      expect(typeof result.object.name).toBe('string');
-      expect(typeof result.object.age).toBe('number');
-      expect(typeof result.object.occupation).toBe('string');
-      expect(result.object.name.length).toBeGreaterThan(0);
-      expect(result.object.age).toBeGreaterThan(0);
-      expect(result.object.occupation.length).toBeGreaterThan(0);
+      expect(result.output).toBeTruthy();
+      expect(typeof result.output.name).toBe('string');
+      expect(typeof result.output.age).toBe('number');
+      expect(typeof result.output.occupation).toBe('string');
+      expect(result.output.name.length).toBeGreaterThan(0);
+      expect(result.output.age).toBeGreaterThan(0);
+      expect(result.output.occupation.length).toBeGreaterThan(0);
     } catch (error) {
       // If structured outputs aren't supported, we'll get an error
       // This is expected for some models

--- a/packages/ai-sdk-ollama/src/integration-tests/json-schema.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/json-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateObject, streamObject, jsonSchema } from 'ai';
+import { generateText, streamText, Output, jsonSchema } from 'ai';
 import { ollama } from '../index';
 
 describe('JSON Schema Integration Tests', { timeout: 120_000 }, () => {
@@ -18,17 +18,17 @@ describe('JSON Schema Integration Tests', { timeout: 120_000 }, () => {
       required: ['name', 'age'],
     });
 
-    const result = await generateObject({
+    const result = await generateText({
       model: ollama('llama3.2'),
       prompt: 'Generate a person named John who is 30 years old',
-      schema,
+      output: Output.object({ schema }),
       temperature: 0,
     });
 
-    expect(result.object).toBeDefined();
-    expect(result.object.name).toBeTruthy();
-    expect(typeof result.object.name).toBe('string');
-    expect(typeof result.object.age).toBe('number');
+    expect(result.output).toBeDefined();
+    expect(result.output.name).toBeTruthy();
+    expect(typeof result.output.name).toBe('string');
+    expect(typeof result.output.age).toBe('number');
   });
 
   it('should stream object with jsonSchema', async () => {
@@ -44,15 +44,15 @@ describe('JSON Schema Integration Tests', { timeout: 120_000 }, () => {
       required: ['title', 'completed'],
     });
 
-    const result = await streamObject({
+    const result = streamText({
       model: ollama('llama3.2'),
       prompt: 'Generate a todo item for grocery shopping',
-      schema,
+      output: Output.object({ schema }),
       temperature: 0,
     });
 
     const chunks: Record<string, unknown>[] = [];
-    for await (const chunk of result.partialObjectStream) {
+    for await (const chunk of result.partialOutputStream) {
       chunks.push(chunk);
     }
 
@@ -84,18 +84,18 @@ describe('JSON Schema Integration Tests', { timeout: 120_000 }, () => {
       required: ['status', 'priority'],
     });
 
-    const result = await generateObject({
+    const result = await generateText({
       model: ollama('llama3.2'),
       prompt: 'Generate a task with high priority that is in progress',
-      schema,
+      output: Output.object({ schema }),
       temperature: 0,
     });
 
-    expect(result.object).toBeDefined();
+    expect(result.output).toBeDefined();
     expect(['pending', 'in_progress', 'completed']).toContain(
-      result.object.status,
+      result.output.status,
     );
-    expect(result.object.priority).toBeGreaterThanOrEqual(1);
-    expect(result.object.priority).toBeLessThanOrEqual(5);
+    expect(result.output.priority).toBeGreaterThanOrEqual(1);
+    expect(result.output.priority).toBeLessThanOrEqual(5);
   });
 });

--- a/packages/ai-sdk-ollama/src/integration-tests/quoted-json.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/quoted-json.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { generateText, Output } from 'ai';
+import { ollama } from '../index';
+import { z } from 'zod';
+
+/**
+ * Integration test for handling JSON wrapped in quotes
+ *
+ * This test verifies that the provider correctly handles cases where
+ * the model returns JSON wrapped in quotes (e.g., "{\"key\": \"value\"}")
+ * or in markdown code blocks, which was causing schema validation failures.
+ *
+ * Issue: https://github.com/jagreehal/ai-sdk-ollama/issues/440
+ */
+describe('Quoted JSON Handling', () => {
+  it('should handle basic object generation with quoted JSON', async () => {
+    // The model might return JSON wrapped in quotes, which should be handled correctly
+    const result = await generateText({
+      model: ollama('llama3.2', {
+        structuredOutputs: true,
+      }),
+      output: Output.object({
+        schema: z.object({
+          name: z.string(),
+          age: z.number(),
+          city: z.string(),
+        }),
+      }),
+      prompt:
+        'Generate a person profile: name "Alice", age 28, city "San Francisco". Return as JSON.',
+    });
+
+    expect(result.output).toBeDefined();
+    expect(result.output.name).toBeTruthy();
+    expect(typeof result.output.name).toBe('string');
+    expect(typeof result.output.age).toBe('number');
+    expect(result.output.city).toBeTruthy();
+    expect(typeof result.output.city).toBe('string');
+    expect(result.output.age).toBeGreaterThan(0);
+  });
+
+  it('should handle complex nested object with quoted JSON', async () => {
+    // Demonstrates that the fix works with nested structures
+    const result = await generateText({
+      model: ollama('llama3.2', {
+        structuredOutputs: true,
+      }),
+      output: Output.object({
+        schema: z.object({
+          recipe: z.object({
+            name: z.string(),
+            ingredients: z.array(
+              z.object({
+                name: z.string(),
+                amount: z.string(),
+              }),
+            ),
+            steps: z.array(z.string()),
+          }),
+        }),
+      }),
+      prompt:
+        'Generate a simple pasta recipe. Return the recipe as a JSON object.',
+    });
+
+    expect(result.output).toBeDefined();
+    expect(result.output.recipe).toBeDefined();
+    expect(result.output.recipe.name).toBeTruthy();
+    expect(typeof result.output.recipe.name).toBe('string');
+    expect(Array.isArray(result.output.recipe.ingredients)).toBe(true);
+    expect(Array.isArray(result.output.recipe.steps)).toBe(true);
+    expect(result.output.recipe.ingredients.length).toBeGreaterThan(0);
+    expect(result.output.recipe.steps.length).toBeGreaterThan(0);
+
+    // Check ingredient structure
+    for (const ingredient of result.output.recipe.ingredients) {
+      expect(typeof ingredient.name).toBe('string');
+      expect(typeof ingredient.amount).toBe('string');
+    }
+
+    // Check steps structure
+    for (const step of result.output.recipe.steps) {
+      expect(typeof step).toBe('string');
+      expect(step.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('should handle array of objects with quoted JSON', async () => {
+    // Shows that arrays are also handled correctly
+    const result = await generateText({
+      model: ollama('llama3.2', {
+        structuredOutputs: true,
+      }),
+      output: Output.object({
+        schema: z.object({
+          items: z.array(
+            z.object({
+              id: z.number(),
+              name: z.string(),
+              price: z.number(),
+            }),
+          ),
+        }),
+      }),
+      prompt:
+        'Generate a list of 3 products with id, name, and price. Return as JSON array.',
+    });
+
+    expect(result.output).toBeDefined();
+    expect(Array.isArray(result.output.items)).toBe(true);
+    expect(result.output.items.length).toBeGreaterThan(0);
+
+    for (const item of result.output.items) {
+      expect(typeof item.id).toBe('number');
+      expect(typeof item.name).toBe('string');
+      expect(typeof item.price).toBe('number');
+      expect(item.name).toBeTruthy();
+      expect(item.price).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('should preserve string values that look like JSON', async () => {
+    // Demonstrates that legitimate string values are not corrupted
+    const result = await generateText({
+      model: ollama('llama3.2', {
+        structuredOutputs: true,
+      }),
+      output: Output.object({
+        schema: z.object({
+          status: z.string(),
+          value: z.string(),
+          note: z.string(),
+        }),
+      }),
+      prompt:
+        'Generate an object with status="True", value="None", and note="/* keep this */". Return as JSON.',
+    });
+
+    expect(result.output).toBeDefined();
+    expect(typeof result.output.status).toBe('string');
+    expect(typeof result.output.value).toBe('string');
+    expect(typeof result.output.note).toBe('string');
+    expect(result.output.status).toBeTruthy();
+    expect(result.output.value).toBeTruthy();
+    expect(result.output.note).toBeTruthy();
+    // String values should be preserved, not converted to booleans/null
+    expect(result.output.status).not.toBe(true);
+    expect(result.output.value).not.toBe(null);
+  });
+});

--- a/packages/ai-sdk-ollama/src/models/chat-language-model-http.test.ts
+++ b/packages/ai-sdk-ollama/src/models/chat-language-model-http.test.ts
@@ -54,7 +54,7 @@ describe('OllamaChatLanguageModel HTTP-level tests', () => {
       expect(result.content).toEqual([
         { type: 'text', text: 'Hello from HTTP test!' },
       ]);
-      expect(result.finishReason).toBe('stop');
+      expect(result.finishReason).toEqual({ unified: 'stop', raw: 'stop' });
 
       // Verify the HTTP request was correct
       const requestBody = await server.calls[0]!.requestBodyJson;

--- a/packages/ai-sdk-ollama/src/models/chat-language-model.test.ts
+++ b/packages/ai-sdk-ollama/src/models/chat-language-model.test.ts
@@ -108,7 +108,7 @@ describe('OllamaChatLanguageModel', () => {
       const result = await model.doGenerate(options);
 
       expect(result.content).toEqual([{ type: 'text', text: 'Hello, world!' }]);
-      expect(result.finishReason).toBe('stop');
+      expect(result.finishReason).toEqual({ unified: 'stop', raw: 'stop' });
       // V3 uses structured usage format
       expect(result.usage).toEqual(createExpectedUsage(5, 10));
 
@@ -411,7 +411,7 @@ describe('OllamaChatLanguageModel', () => {
 
       const result = await model.doGenerate(options);
 
-      expect(result.finishReason).toBe('length');
+      expect(result.finishReason).toEqual({ unified: 'length', raw: 'length' });
     });
   });
 
@@ -504,7 +504,7 @@ describe('OllamaChatLanguageModel', () => {
       });
       expect(chunks[6]).toEqual({
         type: 'finish',
-        finishReason: 'stop',
+        finishReason: { unified: 'stop', raw: 'stop' },
         usage: createExpectedUsage(8, 15),
       });
 
@@ -719,7 +719,7 @@ describe('OllamaChatLanguageModel', () => {
         },
         { type: 'text', text: 'The answer is 42.' },
       ]);
-      expect(result.finishReason).toBe('stop');
+      expect(result.finishReason).toEqual({ unified: 'stop', raw: 'stop' });
       expect(result.usage).toEqual(createExpectedUsage(8, 15));
     });
 
@@ -764,7 +764,7 @@ describe('OllamaChatLanguageModel', () => {
       expect(result.content).toEqual([
         { type: 'text', text: 'The answer is 42.' },
       ]);
-      expect(result.finishReason).toBe('stop');
+      expect(result.finishReason).toEqual({ unified: 'stop', raw: 'stop' });
     });
   });
 
@@ -868,7 +868,7 @@ describe('OllamaChatLanguageModel', () => {
         });
       }
       expect(finish).toBeDefined();
-      expect(finish?.finishReason).toBe('stop');
+      expect(finish?.finishReason).toEqual({ unified: 'stop', raw: 'stop' });
     });
 
     it('should not emit reasoning stream parts when think is disabled', async () => {
@@ -939,7 +939,7 @@ describe('OllamaChatLanguageModel', () => {
         });
       }
       expect(finish).toBeDefined();
-      expect(finish?.finishReason).toBe('stop');
+      expect(finish?.finishReason).toEqual({ unified: 'stop', raw: 'stop' });
     });
   });
 
@@ -1042,7 +1042,7 @@ describe('OllamaChatLanguageModel', () => {
       // Check finish is emitted last
       expect(chunks[6]).toEqual({
         type: 'finish',
-        finishReason: 'stop',
+        finishReason: { unified: 'stop', raw: 'stop' },
         usage: createExpectedUsage(8, 15),
       });
     });
@@ -1085,7 +1085,7 @@ describe('OllamaChatLanguageModel', () => {
       });
       expect(chunks[1]).toEqual({
         type: 'finish',
-        finishReason: 'stop',
+        finishReason: { unified: 'stop', raw: 'stop' },
         usage: createExpectedUsage(5, 0),
       });
     });
@@ -1162,7 +1162,7 @@ describe('OllamaChatLanguageModel', () => {
 
       expect(chunks[4]).toEqual({
         type: 'finish',
-        finishReason: 'stop',
+        finishReason: { unified: 'stop', raw: 'stop' },
         usage: createExpectedUsage(8, 15),
       });
     });

--- a/packages/ai-sdk-ollama/src/models/chat-language-model.ts
+++ b/packages/ai-sdk-ollama/src/models/chat-language-model.ts
@@ -233,7 +233,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
 
   get supportsStructuredOutputs(): boolean {
     // Auto-detect structured outputs when JSON schema is provided
-    // This allows generateObject and streamObject to work without explicit structuredOutputs: true
+    // This allows generateText with Output.object() and streamText with Output.object() to work without explicit structuredOutputs: true
     return this.settings.structuredOutputs ?? false;
   }
 
@@ -254,7 +254,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       if (this.settings.structuredOutputs === false) {
         console.warn(
           'Ollama: structuredOutputs was set to false but auto-enabled for object generation. ' +
-            'This ensures generateObject and streamObject work correctly.',
+            'This ensures generateText with Output.object() and streamText with Output.object() work correctly.',
         );
       }
       return true;

--- a/packages/ai-sdk-ollama/src/utils/map-ollama-finish-reason.test.ts
+++ b/packages/ai-sdk-ollama/src/utils/map-ollama-finish-reason.test.ts
@@ -3,54 +3,95 @@ import { mapOllamaFinishReason } from './map-ollama-finish-reason';
 
 describe('mapOllamaFinishReason', () => {
   describe('valid reasons', () => {
-    it('should map "stop" to "stop"', () => {
-      expect(mapOllamaFinishReason('stop')).toBe('stop');
+    it('should map "stop" to V3 format with unified "stop"', () => {
+      const result = mapOllamaFinishReason('stop');
+      expect(result).toEqual({ unified: 'stop', raw: 'stop' });
     });
 
-    it('should map "length" to "length"', () => {
-      expect(mapOllamaFinishReason('length')).toBe('length');
+    it('should map "length" to V3 format with unified "length"', () => {
+      const result = mapOllamaFinishReason('length');
+      expect(result).toEqual({ unified: 'length', raw: 'length' });
     });
   });
 
   describe('invalid/unknown reasons', () => {
-    it('should map unknown string to "unknown"', () => {
-      expect(mapOllamaFinishReason('unknown_reason')).toBe('unknown');
-      expect(mapOllamaFinishReason('error')).toBe('unknown');
-      expect(mapOllamaFinishReason('timeout')).toBe('unknown');
-      expect(mapOllamaFinishReason('cancelled')).toBe('unknown');
+    it('should map unknown string to V3 format with unified "other"', () => {
+      expect(mapOllamaFinishReason('unknown_reason')).toEqual({
+        unified: 'other',
+        raw: 'unknown_reason',
+      });
+      expect(mapOllamaFinishReason('error')).toEqual({
+        unified: 'other',
+        raw: 'error',
+      });
+      expect(mapOllamaFinishReason('timeout')).toEqual({
+        unified: 'other',
+        raw: 'timeout',
+      });
+      expect(mapOllamaFinishReason('cancelled')).toEqual({
+        unified: 'other',
+        raw: 'cancelled',
+      });
     });
 
-    it('should handle null as "unknown"', () => {
-      expect(mapOllamaFinishReason(null)).toBe('unknown');
+    it('should handle null as unified "stop" (normal completion)', () => {
+      const result = mapOllamaFinishReason(null);
+      expect(result).toEqual({ unified: 'stop', raw: undefined });
     });
 
-    it('should handle undefined as "unknown"', () => {
-      expect(mapOllamaFinishReason()).toBe('unknown');
+    it('should handle undefined as unified "stop" (normal completion)', () => {
+      const result = mapOllamaFinishReason();
+      expect(result).toEqual({ unified: 'stop', raw: undefined });
     });
 
-    it('should handle empty string as "unknown"', () => {
-      expect(mapOllamaFinishReason('')).toBe('unknown');
+    it('should handle empty string as unified "stop" (normal completion)', () => {
+      const result = mapOllamaFinishReason('');
+      expect(result).toEqual({ unified: 'stop', raw: undefined });
     });
   });
 
   describe('case sensitivity', () => {
     it('should be case sensitive for valid reasons', () => {
-      expect(mapOllamaFinishReason('STOP')).toBe('unknown');
-      expect(mapOllamaFinishReason('Stop')).toBe('unknown');
-      expect(mapOllamaFinishReason('LENGTH')).toBe('unknown');
-      expect(mapOllamaFinishReason('Length')).toBe('unknown');
+      expect(mapOllamaFinishReason('STOP')).toEqual({
+        unified: 'other',
+        raw: 'STOP',
+      });
+      expect(mapOllamaFinishReason('Stop')).toEqual({
+        unified: 'other',
+        raw: 'Stop',
+      });
+      expect(mapOllamaFinishReason('LENGTH')).toEqual({
+        unified: 'other',
+        raw: 'LENGTH',
+      });
+      expect(mapOllamaFinishReason('Length')).toEqual({
+        unified: 'other',
+        raw: 'Length',
+      });
     });
   });
 
   describe('edge cases', () => {
-    it('should handle whitespace', () => {
-      expect(mapOllamaFinishReason(' stop ')).toBe('unknown');
-      expect(mapOllamaFinishReason('\tstop\n')).toBe('unknown');
+    it('should handle whitespace as unknown', () => {
+      expect(mapOllamaFinishReason(' stop ')).toEqual({
+        unified: 'other',
+        raw: ' stop ',
+      });
+      expect(mapOllamaFinishReason('\tstop\n')).toEqual({
+        unified: 'other',
+        raw: '\tstop\n',
+      });
     });
 
-    it('should handle special characters', () => {
-      expect(mapOllamaFinishReason('stop!')).toBe('unknown');
-      expect(mapOllamaFinishReason('stop-reason')).toBe('unknown');
+    it('should handle special characters as unknown', () => {
+      expect(mapOllamaFinishReason('stop!')).toEqual({
+        unified: 'other',
+        raw: 'stop!',
+      });
+      expect(mapOllamaFinishReason('stop-reason')).toEqual({
+        unified: 'other',
+        raw: 'stop-reason',
+      });
     });
   });
 });

--- a/packages/ai-sdk-ollama/src/utils/map-ollama-finish-reason.ts
+++ b/packages/ai-sdk-ollama/src/utils/map-ollama-finish-reason.ts
@@ -1,30 +1,42 @@
 import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
 
-// Helper function to create finish reason values
-// TypeScript requires type assertion because LanguageModelV3FinishReason
-// is a branded type that doesn't directly accept string literals
-function createFinishReason(
-  value: 'stop' | 'length' | 'unknown',
-): LanguageModelV3FinishReason {
-  // @ts-expect-error - LanguageModelV3FinishReason is a branded type that requires
-  // type assertion. The values 'stop', 'length', and 'unknown' are valid finish reasons.
-  return value;
-}
-
+/**
+ * Maps Ollama finish reasons to the AI SDK V3 LanguageModelV3FinishReason format.
+ *
+ * In V3, FinishReason is an object with:
+ * - unified: standardized reason ('stop', 'length', 'content-filter', 'tool-calls', 'error', 'other')
+ * - raw: the original reason string from the provider
+ */
 export function mapOllamaFinishReason(
   reason?: string | null,
 ): LanguageModelV3FinishReason {
-  if (!reason) return createFinishReason('unknown');
+  // Map Ollama's finish reasons to AI SDK V3 unified format
+  // Default to 'stop' for undefined/null reasons (normal completion)
+  if (!reason) {
+    return {
+      unified: 'stop',
+      raw: undefined,
+    };
+  }
 
   switch (reason) {
     case 'stop': {
-      return createFinishReason('stop');
+      return {
+        unified: 'stop',
+        raw: reason,
+      };
     }
     case 'length': {
-      return createFinishReason('length');
+      return {
+        unified: 'length',
+        raw: reason,
+      };
     }
     default: {
-      return createFinishReason('unknown');
+      return {
+        unified: 'other',
+        raw: reason,
+      };
     }
   }
 }

--- a/packages/ai-sdk-ollama/src/utils/object-generation-reliability.test.ts
+++ b/packages/ai-sdk-ollama/src/utils/object-generation-reliability.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   enhancedRepairText,
   getRepairFunction,
+  parseJSONWithRepair,
 } from './object-generation-reliability';
 
 describe('Enhanced JSON Repair', () => {
@@ -26,12 +27,134 @@ describe('Enhanced JSON Repair', () => {
     });
 
     it('should fix smart quotes', async () => {
-      const input = '{"name": "John"}'; // curly quotes
+      // Use actual Unicode curly quotes (U+201C and U+201D)
+      const input = '{\u201Cname\u201D: \u201CJohn\u201D}'; // curly quotes
       const result = await enhancedRepairText({
         text: input,
         error: new Error('test'),
       });
       expect(JSON.parse(result!)).toEqual({ name: 'John' });
+    });
+
+    it('should handle multiple smart-quoted fields', async () => {
+      const input =
+        '{\u201Cfirst\u201D: \u201Cone\u201D, \u201Csecond\u201D: \u201Ctwo\u201D}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ first: 'one', second: 'two' });
+    });
+
+    it('should close smart-quoted values before unquoted keys', async () => {
+      const input = '{\u201Cfirst\u201D: \u201Cone\u201D, second: 2}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ first: 'one', second: 2 });
+    });
+
+    it('should close smart-quoted values before numeric keys', async () => {
+      const input = '{\u201Cfirst\u201D: \u201Cone\u201D, 2: "two"}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ first: 'one', 2: 'two' });
+    });
+
+    it('should close smart-quoted keys before Python constants', async () => {
+      const input = '{\u201Cflag\u201D: True}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ flag: true });
+    });
+
+    it('should preserve numeric text inside smart-quoted string values', async () => {
+      const input = '{\u201Cnote\u201D: \u201CValue 123.45\u201D}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ note: 'Value 123.45' });
+    });
+
+    it('should preserve smart quotes inside string values', async () => {
+      const input = '{"quote": "He said \u201CHi\u201D"}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({
+        quote: 'He said \u201CHi\u201D',
+      });
+    });
+
+    it('should preserve Python-looking words inside smart-quoted strings', async () => {
+      const input = '{\u201Cstatus\u201D: \u201CTrue\u201D}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({ status: 'True' });
+    });
+
+    it('should preserve // inside smart-quoted string values', async () => {
+      const input = '{\u201Curl\u201D: \u201Chttps://example.com/a//b\u201D}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({
+        url: 'https://example.com/a//b',
+      });
+    });
+
+    it('should preserve inner smart quotes when smart quotes delimit strings', async () => {
+      const input = '{\u201Cquote\u201D: \u201CHe said \u201CHi\u201D\u201D}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({
+        quote: 'He said \u201CHi\u201D',
+      });
+    });
+
+    it('should keep inner smart quotes when followed by punctuation inside string', async () => {
+      const input =
+        '{\u201Cquote\u201D: \u201CHe said \u201CHi,\u201D and left\u201D}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({
+        quote: 'He said \u201CHi,\u201D and left',
+      });
+    });
+
+    it('should keep inner smart quotes before a colon inside a string', async () => {
+      const input =
+        '{\u201Cquote\u201D: \u201CHe said \u201Ckey:\u201D and left\u201D}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toEqual({
+        quote: 'He said \u201Ckey:\u201D and left',
+      });
+    });
+
+    it('should repair a smart-quoted top-level string', async () => {
+      const input = '\u201CHello\u201D';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result!)).toBe('Hello');
     });
 
     it('should fix unquoted keys', async () => {
@@ -134,6 +257,50 @@ describe('Enhanced JSON Repair', () => {
       expect(JSON.parse(result!)).toEqual({ name: 'John' });
     });
 
+    it('should handle JSON wrapped in quotes', async () => {
+      // Case 1: JSON wrapped in double quotes with escaped quotes
+      const input1 = String.raw`"{\"name\": \"John\", \"age\": 30}"`;
+      const result1 = await enhancedRepairText({
+        text: input1,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result1!)).toEqual({ name: 'John', age: 30 });
+
+      // Case 2: JSON wrapped in single quotes
+      const input2 = '\'{"name": "John", "age": 30}\'';
+      const result2 = await enhancedRepairText({
+        text: input2,
+        error: new Error('test'),
+      });
+      expect(JSON.parse(result2!)).toEqual({ name: 'John', age: 30 });
+    });
+
+    it('should preserve Python constants inside string values', async () => {
+      // Python constants inside strings should NOT be replaced
+      const input = '{"status": "True", "value": "None", "flag": "False"}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      const parsed = JSON.parse(result!);
+      expect(parsed.status).toBe('True');
+      expect(parsed.value).toBe('None');
+      expect(parsed.flag).toBe('False');
+    });
+
+    it('should preserve block comments inside string values', async () => {
+      // Block comments inside strings should NOT be removed
+      const input =
+        '{"note": "/* keep this comment */", "text": "some /* text */ here"}';
+      const result = await enhancedRepairText({
+        text: input,
+        error: new Error('test'),
+      });
+      const parsed = JSON.parse(result!);
+      expect(parsed.note).toBe('/* keep this comment */');
+      expect(parsed.text).toBe('some /* text */ here');
+    });
+
     it('should return null for completely invalid JSON', async () => {
       const input = 'this is not json at all';
       const result = await enhancedRepairText({
@@ -159,6 +326,88 @@ describe('Enhanced JSON Repair', () => {
     it('should return enhanced repair by default', () => {
       const result = getRepairFunction({});
       expect(result).toBe(enhancedRepairText);
+    });
+  });
+
+  describe('parseJSONWithRepair', () => {
+    it('should parse normal JSON', async () => {
+      const result = await parseJSONWithRepair('{"name": "John"}');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ name: 'John' });
+      expect(result.repaired).toBeUndefined();
+    });
+
+    it('should handle JSON wrapped in quotes', async () => {
+      // Case where model returns: "{\"key\": \"value\"}"
+      const input = String.raw`"{\"name\": \"John\", \"age\": 30}"`;
+      const result = await parseJSONWithRepair(input);
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ name: 'John', age: 30 });
+      expect(result.repaired).toBe(true);
+    });
+
+    it('should handle JSON array wrapped in quotes', async () => {
+      const input = String.raw`"{\"items\": [1, 2, 3]}"`;
+      const result = await parseJSONWithRepair(input);
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ items: [1, 2, 3] });
+      expect(result.repaired).toBe(true);
+    });
+
+    it('should not re-parse valid JSON strings that are meant to be strings', async () => {
+      // A string value that happens to look like JSON should remain a string
+      const input = '"hello world"';
+      const result = await parseJSONWithRepair(input);
+      expect(result.success).toBe(true);
+      expect(result.data).toBe('hello world');
+    });
+
+    it('should use repair function when JSON parsing fails', async () => {
+      const input = '{"name": "John",}'; // trailing comma
+      const repairFn = getRepairFunction({});
+      const result = await parseJSONWithRepair(input, repairFn);
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ name: 'John' });
+      expect(result.repaired).toBe(true);
+    });
+  });
+
+  describe('attemptSchemaRecovery', () => {
+    it('should handle non-object schemas (string, number, array)', async () => {
+      const { attemptSchemaRecovery } =
+        await import('./object-generation-reliability');
+
+      // Test string schema
+      const stringResult = await attemptSchemaRecovery('"hello"', {
+        type: 'string',
+      });
+      expect(stringResult.success).toBe(true);
+      expect(stringResult.object).toBe('hello');
+
+      // Test number schema
+      const numberResult = await attemptSchemaRecovery('42', {
+        type: 'number',
+      });
+      expect(numberResult.success).toBe(true);
+      expect(numberResult.object).toBe(42);
+
+      // Test array schema
+      const arrayResult = await attemptSchemaRecovery('[1, 2, 3]', {
+        type: 'array',
+      });
+      expect(arrayResult.success).toBe(true);
+      expect(Array.isArray(arrayResult.object)).toBe(true);
+      expect(arrayResult.object).toEqual([1, 2, 3]);
+    });
+
+    it('should reject values that do not match union schema types', async () => {
+      const { attemptSchemaRecovery } =
+        await import('./object-generation-reliability');
+
+      const result = await attemptSchemaRecovery('true', {
+        type: ['string', 'number'],
+      });
+      expect(result.success).toBe(false);
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^62.0.0
         version: 62.0.0(eslint@9.39.2(jiti@2.6.1))
       prettier:
-        specifier: ^3.8.0
-        version: 3.8.0
+        specifier: ^3.8.1
+        version: 3.8.1
       turbo:
         specifier: ^2.7.5
         version: 2.7.5
@@ -49,8 +49,8 @@ importers:
   examples/browser:
     dependencies:
       '@ai-sdk/react':
-        specifier: ^3.0.44
-        version: 3.0.44(react@19.2.3)(zod@4.3.5)
+        specifier: ^3.0.46
+        version: 3.0.46(react@19.2.3)(zod@4.3.5)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.9))(@types/react@19.2.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -85,8 +85,8 @@ importers:
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       ai:
-        specifier: ^6.0.42
-        version: 6.0.42(zod@4.3.5)
+        specifier: ^6.0.44
+        version: 6.0.44(zod@4.3.5)
       ai-sdk-ollama:
         specifier: workspace:*
         version: link:../../packages/ai-sdk-ollama
@@ -164,8 +164,8 @@ importers:
         specifier: ^1.0.11
         version: 1.0.11(zod@4.3.5)
       ai:
-        specifier: ^6.0.42
-        version: 6.0.42(zod@4.3.5)
+        specifier: ^6.0.44
+        version: 6.0.44(zod@4.3.5)
       ai-sdk-ollama:
         specifier: workspace:*
         version: link:../../packages/ai-sdk-ollama
@@ -201,8 +201,8 @@ importers:
         specifier: ^4.0.8
         version: 4.0.8(zod@4.3.5)
       ai:
-        specifier: ^6.0.27
-        version: 6.0.27(zod@4.3.5)
+        specifier: ^6.0.44
+        version: 6.0.44(zod@4.3.5)
       ollama:
         specifier: ^0.6.3
         version: 0.6.3
@@ -241,8 +241,8 @@ importers:
         specifier: ^62.0.0
         version: 62.0.0(eslint@9.39.2(jiti@2.6.1))
       prettier:
-        specifier: ^3.8.0
-        version: 3.8.0
+        specifier: ^3.8.1
+        version: 3.8.1
       rimraf:
         specifier: ^6.1.2
         version: 6.1.2
@@ -259,22 +259,16 @@ importers:
         specifier: ^6.0.4
         version: 6.0.4(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       vitest:
-        specifier: ^4.0.16
-        version: 4.0.16(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(tsx@4.21.0)
+        specifier: ^4.0.17
+        version: 4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(tsx@4.21.0)
       zod:
         specifier: ^4.3.5
         version: 4.3.5
 
 packages:
 
-  '@ai-sdk/gateway@3.0.11':
-    resolution: {integrity: sha512-gLrgNXA95wdo/zAlA0miX/SJEYKSYCHg+e0Y/uQeABLScZAMjPw3jWaeANta/Db1T4xfi8cBvY3nnV8Pa27z+w==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/gateway@3.0.17':
-    resolution: {integrity: sha512-mCz50GlBPyBV96Wcll1Mpaz56MVFuHL+bwRWGkIsCJwKAKIfdgUZecFzS3gckpHGaqP5+BYnmyJocIMzUhTQ2A==}
+  '@ai-sdk/gateway@3.0.18':
+    resolution: {integrity: sha512-WlJ7UkBDYgv+5q9UpGZfbnPrrW3KVnY96lRLaXs8nXy7Ea3QTWXf4Jw43jFzMSVkH4Zhhf0s9ExmG+CiyEBY5A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -285,28 +279,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.4':
-    resolution: {integrity: sha512-VxhX0B/dWGbpNHxrKCWUAJKXIXV015J4e7qYjdIU9lLWeptk0KMLGcqkB4wFxff5Njqur8dt8wRi1MN9lZtDqg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   '@ai-sdk/provider-utils@4.0.8':
     resolution: {integrity: sha512-ns9gN7MmpI8vTRandzgz+KK/zNMLzhrriiKECMt4euLtQFSBgNfydtagPOX4j4pS1/3KvHF6RivhT3gNQgBZsg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.2':
-    resolution: {integrity: sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw==}
-    engines: {node: '>=18'}
-
   '@ai-sdk/provider@3.0.4':
     resolution: {integrity: sha512-5KXyBOSEX+l67elrEa+wqo/LSsSTtrPj9Uoh3zMbe/ceQX4ucHI3b9nUEfNkGF3Ry1svv90widAt+aiKdIJasQ==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@3.0.44':
-    resolution: {integrity: sha512-TiCzQMRJZ8ASZjemz9eeX0/C5f6G1boRhrxVE3aNKvpuO/RUVQvkHsCIiJF3JgCyCEgQo//BqrXah1aSqgKDDA==}
+  '@ai-sdk/react@3.0.46':
+    resolution: {integrity: sha512-0WVvenCr8RymOG3tVP3BESkSjanqAO5yv1pYEz8T80iVI3YpGH19a3lLDiIU58kJm+SE8PIBNKfteXPHAQL0AQ==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
@@ -1819,11 +1803,11 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
-  '@vitest/expect@4.0.16':
-    resolution: {integrity: sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==}
+  '@vitest/expect@4.0.17':
+    resolution: {integrity: sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==}
 
-  '@vitest/mocker@4.0.16':
-    resolution: {integrity: sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==}
+  '@vitest/mocker@4.0.17':
+    resolution: {integrity: sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0-0
@@ -1833,20 +1817,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.16':
-    resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
+  '@vitest/pretty-format@4.0.17':
+    resolution: {integrity: sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==}
 
-  '@vitest/runner@4.0.16':
-    resolution: {integrity: sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==}
+  '@vitest/runner@4.0.17':
+    resolution: {integrity: sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==}
 
-  '@vitest/snapshot@4.0.16':
-    resolution: {integrity: sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==}
+  '@vitest/snapshot@4.0.17':
+    resolution: {integrity: sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==}
 
-  '@vitest/spy@4.0.16':
-    resolution: {integrity: sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==}
+  '@vitest/spy@4.0.17':
+    resolution: {integrity: sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==}
 
-  '@vitest/utils@4.0.16':
-    resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
+  '@vitest/utils@4.0.17':
+    resolution: {integrity: sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1858,14 +1842,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ai@6.0.27:
-    resolution: {integrity: sha512-a4ToMt5+4xOzHuYdoTy2GQXuNa2/Tpuhxfs5QESHtEV/Vf2HAzSwmTwikrIs8CDKPuMWV1I9YqAvaN5xexMCiQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  ai@6.0.42:
-    resolution: {integrity: sha512-o+MVN7HBE4HEnhtN7nBt9WO1iISI6svyWNoOuY6WiXCdHuZfSGN4MUQ3QwjWz1Ue5gtBEcvwX5XFhgAwlPAxxw==}
+  ai@6.0.44:
+    resolution: {integrity: sha512-fOyssuNfSB3i3ODuDeLaWambfJY+gE3LRHQf4nmWEPDrQhfiB+fcpVMVi77LbFRBfoG/h5BrmX0heVqz4Hl7ug==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -3115,8 +3093,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.8.0:
-    resolution: {integrity: sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==}
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3714,18 +3692,18 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.0.16:
-    resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
+  vitest@4.0.17:
+    resolution: {integrity: sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.16
-      '@vitest/browser-preview': 4.0.16
-      '@vitest/browser-webdriverio': 4.0.16
-      '@vitest/ui': 4.0.16
+      '@vitest/browser-playwright': 4.0.17
+      '@vitest/browser-preview': 4.0.17
+      '@vitest/browser-webdriverio': 4.0.17
+      '@vitest/ui': 4.0.17
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -3816,14 +3794,7 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.11(zod@4.3.5)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.2
-      '@ai-sdk/provider-utils': 4.0.4(zod@4.3.5)
-      '@vercel/oidc': 3.1.0
-      zod: 4.3.5
-
-  '@ai-sdk/gateway@3.0.17(zod@4.3.5)':
+  '@ai-sdk/gateway@3.0.18(zod@4.3.5)':
     dependencies:
       '@ai-sdk/provider': 3.0.4
       '@ai-sdk/provider-utils': 4.0.8(zod@4.3.5)
@@ -3837,13 +3808,6 @@ snapshots:
       pkce-challenge: 5.0.1
       zod: 4.3.5
 
-  '@ai-sdk/provider-utils@4.0.4(zod@4.3.5)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.2
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 4.3.5
-
   '@ai-sdk/provider-utils@4.0.8(zod@4.3.5)':
     dependencies:
       '@ai-sdk/provider': 3.0.4
@@ -3851,18 +3815,14 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.5
 
-  '@ai-sdk/provider@3.0.2':
-    dependencies:
-      json-schema: 0.4.0
-
   '@ai-sdk/provider@3.0.4':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.44(react@19.2.3)(zod@4.3.5)':
+  '@ai-sdk/react@3.0.46(react@19.2.3)(zod@4.3.5)':
     dependencies:
       '@ai-sdk/provider-utils': 4.0.8(zod@4.3.5)
-      ai: 6.0.42(zod@4.3.5)
+      ai: 6.0.44(zod@4.3.5)
       react: 19.2.3
       swr: 2.3.8(react@19.2.3)
       throttleit: 2.1.0
@@ -5224,44 +5184,44 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitest/expect@4.0.16':
+  '@vitest/expect@4.0.17':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.16
-      '@vitest/utils': 4.0.16
+      '@vitest/spy': 4.0.17
+      '@vitest/utils': 4.0.17
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.16(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.17(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
-      '@vitest/spy': 4.0.16
+      '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@25.0.9)(typescript@5.9.3)
       vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
-  '@vitest/pretty-format@4.0.16':
+  '@vitest/pretty-format@4.0.17':
     dependencies:
       tinyrainbow: 3.0.3
 
-  '@vitest/runner@4.0.16':
+  '@vitest/runner@4.0.17':
     dependencies:
-      '@vitest/utils': 4.0.16
+      '@vitest/utils': 4.0.17
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.16':
+  '@vitest/snapshot@4.0.17':
     dependencies:
-      '@vitest/pretty-format': 4.0.16
+      '@vitest/pretty-format': 4.0.17
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.16': {}
+  '@vitest/spy@4.0.17': {}
 
-  '@vitest/utils@4.0.16':
+  '@vitest/utils@4.0.17':
     dependencies:
-      '@vitest/pretty-format': 4.0.16
+      '@vitest/pretty-format': 4.0.17
       tinyrainbow: 3.0.3
 
   acorn-jsx@5.3.2(acorn@8.15.0):
@@ -5270,17 +5230,9 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ai@6.0.27(zod@4.3.5):
+  ai@6.0.44(zod@4.3.5):
     dependencies:
-      '@ai-sdk/gateway': 3.0.11(zod@4.3.5)
-      '@ai-sdk/provider': 3.0.2
-      '@ai-sdk/provider-utils': 4.0.4(zod@4.3.5)
-      '@opentelemetry/api': 1.9.0
-      zod: 4.3.5
-
-  ai@6.0.42(zod@4.3.5):
-    dependencies:
-      '@ai-sdk/gateway': 3.0.17(zod@4.3.5)
+      '@ai-sdk/gateway': 3.0.18(zod@4.3.5)
       '@ai-sdk/provider': 3.0.4
       '@ai-sdk/provider-utils': 4.0.8(zod@4.3.5)
       '@opentelemetry/api': 1.9.0
@@ -6731,7 +6683,7 @@ snapshots:
 
   prettier@2.8.8: {}
 
-  prettier@3.8.0: {}
+  prettier@3.8.1: {}
 
   prismjs@1.30.0: {}
 
@@ -7349,15 +7301,15 @@ snapshots:
       lightningcss: 1.30.2
       tsx: 4.21.0
 
-  vitest@4.0.16(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(tsx@4.21.0):
+  vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(tsx@4.21.0):
     dependencies:
-      '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
-      '@vitest/pretty-format': 4.0.16
-      '@vitest/runner': 4.0.16
-      '@vitest/snapshot': 4.0.16
-      '@vitest/spy': 4.0.16
-      '@vitest/utils': 4.0.16
+      '@vitest/expect': 4.0.17
+      '@vitest/mocker': 4.0.17(msw@2.12.7(@types/node@25.0.9)(typescript@5.9.3))(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.17
+      '@vitest/runner': 4.0.17
+      '@vitest/snapshot': 4.0.17
+      '@vitest/spy': 4.0.17
+      '@vitest/utils': 4.0.17
       es-module-lexer: 1.7.0
       expect-type: 1.2.2
       magic-string: 0.30.21


### PR DESCRIPTION
- Bump `prettier` from `3.8.0` to `3.8.1`.
- Update `@ai-sdk/react` from `3.0.44` to `3.0.46`.
- Upgrade `ai` from `6.0.42` to `6.0.44`.
- Bump `@vitest/snapshot`, `@vitest/spy`, and `@vitest/utils` from `4.0.16` to `4.0.17`.
- Enhance JSON repair functionality in the object generation utility, including handling smart quotes and various edge cases.
- Update README and examples to reflect changes in the API, specifically the transition from `generateObject` to `generateText` with `Output.object()`.