### PR TITLE
fix: repair npm upgrade step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npx npm@11 install -g npm@11
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## Summary

This PR fixes the release workflow failure caused by the GitHub runner's bundled npm failing during `npm install -g npm@latest`.

## Change

- replace `npm install -g npm@latest` with `npx npm@11 install -g npm@11` in the release workflow

## Why

The release job runs on Node 22, and the bundled npm on the runner is resolving a broken internal dependency (`promise-retry`). Using `npx npm@11` avoids relying on the preinstalled npm to upgrade itself.
