### PR TITLE
fix: report tool-call finish reason

### DIFF
--- a/.changeset/tool-call-finish-reason.md
+++ b/.changeset/tool-call-finish-reason.md
@@ -1,0 +1,5 @@
+---
+'ai-sdk-ollama': patch
+---
+
+Return AI SDK `tool-calls` finish reasons when Ollama responses emit tool calls.

--- a/packages/ai-sdk-ollama/src/models/chat-language-model.test.ts
+++ b/packages/ai-sdk-ollama/src/models/chat-language-model.test.ts
@@ -268,6 +268,72 @@ describe('OllamaChatLanguageModel', () => {
       );
     });
 
+    it('should return tool-calls finish reason when generation emits tool calls', async () => {
+      const mockResponse = {
+        model: 'llama3.2',
+        created_at: new Date(),
+        message: {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              function: {
+                name: 'get_weather',
+                arguments: { location: 'Paris' },
+              },
+            },
+          ],
+        },
+        done: true,
+        done_reason: 'stop',
+        eval_count: 10,
+        prompt_eval_count: 5,
+        total_duration: 1_000_000_000,
+        load_duration: 100_000_000,
+        prompt_eval_duration: 200_000_000,
+        eval_duration: 700_000_000,
+      };
+
+      vi.mocked(mockOllamaClient.chat).mockResolvedValueOnce(mockResponse);
+
+      const options: LanguageModelV3CallOptions = {
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'What is the weather?' }],
+          },
+        ],
+        tools: [
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get weather for a city',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                location: { type: 'string' },
+              },
+            },
+          },
+        ],
+      };
+
+      const result = await model.doGenerate(options);
+
+      expect(result.finishReason).toEqual({
+        unified: 'tool-calls',
+        raw: 'stop',
+      });
+      expect(result.content).toEqual([
+        {
+          type: 'tool-call',
+          toolCallId: expect.any(String),
+          toolName: 'get_weather',
+          input: JSON.stringify({ location: 'Paris' }),
+        },
+      ]);
+    });
+
     it('should force completion when tool calls succeed without final text', async () => {
       // Create model with reliableToolCalling enabled for this test
       const reliableModel = new OllamaChatLanguageModel(
@@ -514,6 +580,100 @@ describe('OllamaChatLanguageModel', () => {
         stream: true,
         options: expect.objectContaining({}),
       });
+    });
+
+    it('should return tool-calls finish reason when stream emits tool calls', async () => {
+      const mockStreamData = [
+        {
+          model: 'llama3.2',
+          created_at: new Date(),
+          message: {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                function: {
+                  name: 'get_weather',
+                  arguments: { location: 'Paris' },
+                },
+              },
+            ],
+          },
+          done: false,
+          done_reason: '',
+          eval_count: 5,
+          prompt_eval_count: 3,
+          total_duration: 500_000_000,
+          load_duration: 50_000_000,
+          prompt_eval_duration: 100_000_000,
+          eval_duration: 350_000_000,
+        },
+        {
+          model: 'llama3.2',
+          created_at: new Date(),
+          message: { role: 'assistant', content: '' },
+          done: true,
+          done_reason: 'stop',
+          eval_count: 10,
+          prompt_eval_count: 5,
+          total_duration: 1_000_000_000,
+          load_duration: 100_000_000,
+          prompt_eval_duration: 200_000_000,
+          eval_duration: 700_000_000,
+        },
+      ];
+
+      mockChatStream(mockStreamData);
+
+      const options: LanguageModelV3CallOptions = {
+        prompt: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'What is the weather?' }],
+          },
+        ],
+        tools: [
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get weather for a city',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                location: { type: 'string' },
+              },
+            },
+          },
+        ],
+      };
+
+      const { stream } = await model.doStream(options);
+      const chunks = [];
+
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual([
+        {
+          type: 'stream-start',
+          warnings: [],
+        },
+        {
+          type: 'tool-call',
+          toolCallId: expect.any(String),
+          toolName: 'get_weather',
+          input: JSON.stringify({ location: 'Paris' }),
+        },
+        {
+          type: 'finish',
+          finishReason: {
+            unified: 'tool-calls',
+            raw: 'stop',
+          },
+          usage: createExpectedUsage(5, 10),
+        },
+      ]);
     });
 
     it('should handle streaming errors', async () => {

--- a/packages/ai-sdk-ollama/src/models/chat-language-model.ts
+++ b/packages/ai-sdk-ollama/src/models/chat-language-model.ts
@@ -622,12 +622,10 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
         }
       }
 
-      // Determine finish reason - when tool calls are present, use 'stop' as the finish reason
-      // (tool calls are already represented in the content array)
-      const finishReason: LanguageModelV3FinishReason =
-        parsedToolCalls.length > 0
-          ? mapOllamaFinishReason('stop')
-          : mapOllamaFinishReason(response.done_reason);
+      const finishReason = mapOllamaFinishReason(
+        response.done_reason,
+        parsedToolCalls.length > 0,
+      );
 
       return {
         content,
@@ -1435,11 +1433,10 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
               chunk.prompt_eval_count ?? undefined,
               chunk.eval_count ?? undefined,
             );
-            // If we saw tool calls, use 'stop' as the finish reason
-            // (tool calls are already represented in the content array)
-            finishReason = hasToolCalls
-              ? mapOllamaFinishReason('stop')
-              : mapOllamaFinishReason(chunk.done_reason);
+            finishReason = mapOllamaFinishReason(
+              chunk.done_reason,
+              hasToolCalls,
+            );
 
             controller.enqueue({
               type: 'finish',

--- a/packages/ai-sdk-ollama/src/utils/map-ollama-finish-reason.test.ts
+++ b/packages/ai-sdk-ollama/src/utils/map-ollama-finish-reason.test.ts
@@ -12,6 +12,16 @@ describe('mapOllamaFinishReason', () => {
       const result = mapOllamaFinishReason('length');
       expect(result).toEqual({ unified: 'length', raw: 'length' });
     });
+
+    it('should map tool-call responses to unified "tool-calls"', () => {
+      const result = mapOllamaFinishReason('stop', true);
+      expect(result).toEqual({ unified: 'tool-calls', raw: 'stop' });
+    });
+
+    it('should omit raw reason for tool-call responses without a done reason', () => {
+      const result = mapOllamaFinishReason(null, true);
+      expect(result).toEqual({ unified: 'tool-calls', raw: undefined });
+    });
   });
 
   describe('invalid/unknown reasons', () => {

--- a/packages/ai-sdk-ollama/src/utils/map-ollama-finish-reason.ts
+++ b/packages/ai-sdk-ollama/src/utils/map-ollama-finish-reason.ts
@@ -9,7 +9,15 @@ import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
  */
 export function mapOllamaFinishReason(
   reason?: string | null,
+  hasToolCalls = false,
 ): LanguageModelV3FinishReason {
+  if (hasToolCalls) {
+    return {
+      unified: 'tool-calls',
+      raw: reason || undefined,
+    };
+  }
+
   // Map Ollama's finish reasons to AI SDK V3 unified format
   // Default to 'stop' for undefined/null reasons (normal completion)
   if (!reason) {


### PR DESCRIPTION
## Summary
- report AI SDK `tool-calls` as the unified finish reason when Ollama responses include tool calls
- preserve Ollama’s raw `done_reason` on the finish reason object
- add focused unit coverage for non-streaming and streaming tool-call responses
- add a patch changeset

## Validation
- `corepack pnpm@10.27.0 --filter ai-sdk-ollama test`
- `corepack pnpm@10.27.0 --filter ai-sdk-ollama type-check`
- `corepack pnpm@10.27.0 --filter ai-sdk-ollama format:check`
- `corepack pnpm@10.27.0 --filter ai-sdk-ollama build`
- `corepack pnpm@10.27.0 --filter ai-sdk-ollama check-exports`
- `corepack pnpm@10.27.0 --filter ai-sdk-ollama exec eslint src/models/chat-language-model.ts src/models/chat-language-model.test.ts src/utils/map-ollama-finish-reason.ts src/utils/map-ollama-finish-reason.test.ts`

Note: `corepack pnpm@10.27.0 --filter ai-sdk-ollama lint` currently fails on unrelated existing Unicorn rule violations in other files; the changed files pass ESLint.