### PR TITLE
feat!: support AI SDK v7 (provider spec V4)

### DIFF
--- a/.changeset/ai-sdk-v7-support.md
+++ b/.changeset/ai-sdk-v7-support.md
@@ -1,0 +1,13 @@
+---
+'ai-sdk-ollama': major
+---
+
+Add support for Vercel AI SDK v7 (beta).
+
+- Bump peer dependency to `ai@^7`, and dependencies to `@ai-sdk/provider@4` and `@ai-sdk/provider-utils@5`.
+- Migrate all models (chat, embedding, image, reranking) to the `LanguageModelV4` / `EmbeddingModelV4` / `ImageModelV4` / `RerankingModelV4` provider specs, declaring `specificationVersion: 'v4'`.
+- Read the new `SharedV4FileData` tagged file-data union for image inputs, and the consolidated `file` tool-result output type (was `image-data` / `image-url` / `file-data`). Fixes multimodal image inputs under v7.
+- Update the `tool()` helper usages (web search / web fetch) for the v7 `ToolExecutionOptions` and 3-generic `Tool<INPUT, OUTPUT, CONTEXT>` signature.
+- Support the new per-call `reasoning` effort option (`LanguageModelV4CallOptions.reasoning`). The provider maps `'none'`/`'minimal'`/`'low'`/`'medium'`/`'high'`/`'xhigh'`/`'provider-default'` onto Ollama's `think` parameter, overriding the model-level `think` setting, so you can set reasoning effort per request.
+
+BREAKING: This release requires `ai@^7`. AI SDK v7 renamed the re-exported agent callback types `ToolLoopAgentOnFinishCallback` and `ToolLoopAgentOnStepFinishCallback` to `GenerateTextOnFinishCallback` and `GenerateTextOnStepFinishCallback`.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@examples/browser": "1.0.0",
+    "@examples/node": "1.0.0",
+    "ai-sdk-ollama": "3.8.7"
+  },
+  "changesets": []
+}

--- a/README.md
+++ b/README.md
@@ -5,14 +5,28 @@
 [![Node.js](https://img.shields.io/badge/Node.js-22+-green.svg)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A Vercel AI SDK v6 provider for Ollama built on the official `ollama` package. Type safe, future proof, with cross provider compatibility and native Ollama features.
+A Vercel AI SDK provider for Ollama built on the official `ollama` package. Type safe, future proof, with cross provider compatibility and native Ollama features.
 
-> **📌 Version Compatibility**: This version (v3+) requires AI SDK v6. If you're using AI SDK v5, please use `ai-sdk-ollama@^2.2.0` instead.
+> **📌 Version compatibility**
+>
+> Each `ai-sdk-ollama` major targets one AI SDK major. Every line stays published on npm, so pick the one that matches your `ai` version:
+>
+> | `ai-sdk-ollama` | `ai` (peer) | Status |
+> | --- | --- | --- |
+> | `4.x` (`@beta`) | `ai@^7` (beta) | Active. New features land here. |
+> | `3.x` | `ai@^6` | Maintenance. Critical fixes only. |
+> | `2.x` | `ai@^5` | Unmaintained. |
+>
+> While AI SDK v7 is in beta, install v4 from the `beta` tag. The v3 line keeps working for AI SDK v6 the whole time. Once AI SDK v7 ships stable, v4 moves to the `latest` tag.
 
 ## Quick Start
 
 ```bash
-npm install ai-sdk-ollama ai@^6.0.0
+# AI SDK v7 (beta)
+npm install ai-sdk-ollama@beta ai@beta
+
+# AI SDK v6 (stable)
+npm install ai-sdk-ollama@^3 ai@^6
 ```
 
 ```typescript

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -16,7 +16,7 @@
     "quality": "pnpm type-check && pnpm build"
   },
   "dependencies": {
-    "@ai-sdk/react": "^3.0.208",
+    "@ai-sdk/react": "4.0.0-beta.183",
     "@radix-ui/react-avatar": "^1.2.0",
     "@radix-ui/react-collapsible": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.18",
@@ -28,7 +28,7 @@
     "@radix-ui/react-tooltip": "^1.2.10",
     "@radix-ui/react-use-controllable-state": "^1.2.3",
     "@tailwindcss/vite": "^4.3.1",
-    "ai": "^6.0.207",
+    "ai": "7.0.0-beta.179",
     "ai-sdk-ollama": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/examples/browser/src/components/ai-elements/context.tsx
+++ b/examples/browser/src/components/ai-elements/context.tsx
@@ -314,7 +314,7 @@ export const ContextReasoningUsage = ({
   ...props
 }: ContextReasoningUsageProps) => {
   const { usage, modelId } = useContextValue();
-  const reasoningTokens = usage?.reasoningTokens ?? 0;
+  const reasoningTokens = usage?.outputTokenDetails?.reasoningTokens ?? 0;
 
   if (children) {
     return children;
@@ -354,7 +354,7 @@ export const ContextCacheUsage = ({
   ...props
 }: ContextCacheUsageProps) => {
   const { usage, modelId } = useContextValue();
-  const cacheTokens = usage?.cachedInputTokens ?? 0;
+  const cacheTokens = usage?.inputTokenDetails?.cacheReadTokens ?? 0;
 
   if (children) {
     return children;

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -28,6 +28,51 @@ pnpm install
 npx tsx examples/[example-name].ts
 ```
 
+## 🆕 **AI SDK v7 Features**
+
+These examples showcase new functions introduced in AI SDK v7, running against Ollama.
+
+### **agent-tool-loop-example.ts** - ToolLoopAgent + isStepCount
+
+The new `ToolLoopAgent` class bundles a model, instructions, tools, and a stop
+condition into a reusable agent that runs the tool-calling loop for you.
+Uses `isStepCount(n)` (the renamed `stepCountIs`) as the stop condition.
+
+```bash
+npx tsx src/agent-tool-loop-example.ts
+```
+
+### **tool-approval-example.ts** - Tool Approval (human-in-the-loop)
+
+v7 replaces per-tool `needsApproval` with a `toolApproval` policy on
+`generateText` / `streamText` / `ToolLoopAgent`. The policy can auto-approve,
+auto-deny (`{ type: 'denied', reason }`), or route to a human (`'user-approval'`),
+which you answer with a `ToolApprovalResponse`.
+
+```bash
+npx tsx src/tool-approval-example.ts
+```
+
+### **rerank-example.ts** - rerank
+
+The new `rerank` core function reorders documents by relevance to a query.
+Uses `ollama.embeddingReranking(...)` as the `RerankingModel`.
+
+```bash
+npx tsx src/rerank-example.ts
+```
+
+### **reasoning-effort-example.ts** - Per-call reasoning effort
+
+v7 adds a standard `reasoning` option (`'none'` | `'low'` | `'medium'` | `'high'` | …)
+to `generateText` / `streamText` / `ToolLoopAgent`. This provider maps it onto
+Ollama's `think` parameter, so reasoning effort can be set per request without
+changing the model's `think` setting. Needs a reasoning model (e.g. `qwen3.5`).
+
+```bash
+npx tsx src/reasoning-effort-example.ts
+```
+
 ## 🎯 **Essential Examples (Start Here)**
 
 ### **basic-chat.ts** - Quick Start

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -8,8 +8,8 @@
     "quality": "pnpm build"
   },
   "dependencies": {
-    "@ai-sdk/mcp": "^1.0.52",
-    "ai": "^6.0.207",
+    "@ai-sdk/mcp": "2.0.0-beta.66",
+    "ai": "7.0.0-beta.179",
     "ai-sdk-ollama": "workspace:*",
     "dotenv": "^17.4.2",
     "ollama": "^0.6.3",

--- a/examples/node/src/agent-tool-loop-example.ts
+++ b/examples/node/src/agent-tool-loop-example.ts
@@ -1,0 +1,76 @@
+/**
+ * AI SDK v7: `ToolLoopAgent` + `isStepCount`
+ *
+ * `ToolLoopAgent` is the new v7 agent abstraction: a reusable object that
+ * bundles a model, instructions, tools, and a stop condition. It runs the
+ * tool-calling loop for you until the `stopWhen` condition is met.
+ *
+ * `isStepCount(n)` is the v7 stop-condition helper (renamed from `stepCountIs`).
+ *
+ * Run: pnpm --filter @examples/node exec tsx src/agent-tool-loop-example.ts
+ */
+import { ollama } from 'ai-sdk-ollama';
+import { ToolLoopAgent, isStepCount, tool } from 'ai';
+import { z } from 'zod';
+import { MODELS } from './model';
+
+const calculator = tool({
+  description:
+    'Evaluate a single arithmetic operation on two numbers. Always use this for math.',
+  inputSchema: z.object({
+    a: z.number(),
+    b: z.number(),
+    op: z.enum(['add', 'subtract', 'multiply', 'divide']),
+  }),
+  execute: async ({ a, b, op }) => {
+    const result =
+      op === 'add'
+        ? a + b
+        : op === 'subtract'
+          ? a - b
+          : op === 'multiply'
+            ? a * b
+            : a / b;
+    return { result };
+  },
+});
+
+const weather = tool({
+  description: 'Get the current weather for a city.',
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }) => ({ city, tempC: 21, condition: 'sunny' }),
+});
+
+// Define the agent once and reuse it across calls.
+const agent = new ToolLoopAgent({
+  model: ollama(MODELS.LLAMA_3_2),
+  instructions:
+    'You are a concise assistant. Use the calculator tool for any arithmetic ' +
+    'and the weather tool for any weather question. After using tools, give a short final answer.',
+  tools: { calculator, weather },
+  // Stop after at most 5 steps (model call + tool round-trips).
+  stopWhen: isStepCount(5),
+});
+
+async function main() {
+  console.log('=== ToolLoopAgent (v7) ===\n');
+
+  const result = await agent.generate({
+    prompt: 'What is 23 multiplied by 7, and what is the weather in Paris?',
+  });
+
+  console.log(`Steps taken: ${result.steps.length}`);
+  const toolCalls = result.steps.flatMap((step) => step.toolCalls);
+  for (const call of toolCalls) {
+    console.log(`  → called ${call.toolName}(${JSON.stringify(call.input)})`);
+  }
+
+  console.log(`\nFinal answer:\n${result.text}`);
+  console.log(`\nfinishReason: ${result.finishReason}`);
+  console.log(`usage: ${JSON.stringify(result.usage)}`);
+}
+
+main().catch((error) => {
+  console.error('Error:', error);
+  process.exit(1);
+});

--- a/examples/node/src/model.ts
+++ b/examples/node/src/model.ts
@@ -8,6 +8,7 @@ export const MODELS = {
   QWEN_2_5_CODER: 'qwen2.5-coder:latest',
   NOMIC_EMBED_TEXT: 'nomic-embed-text',
   DEEPSEEK_R1_7B: 'deepseek-r1:7b',
+  QWEN_3_5: 'qwen3.5:latest',
   GRANITE_4: 'granite4',
 
   // Cloud models (recommended for web search)

--- a/examples/node/src/reasoning-effort-example.ts
+++ b/examples/node/src/reasoning-effort-example.ts
@@ -1,0 +1,64 @@
+/**
+ * AI SDK v7: per-call `reasoning` effort
+ *
+ * v7 adds a standard `reasoning` option to `generateText` / `streamText` /
+ * `ToolLoopAgent`. This provider maps it onto Ollama's `think` parameter, so you
+ * can control reasoning effort per request (overriding the model-level `think`
+ * setting):
+ *
+ *   'none'                 -> think: false   (disable thinking)
+ *   'minimal' | 'low'      -> think: 'low'
+ *   'medium'               -> think: 'medium'
+ *   'high'   | 'xhigh'     -> think: 'high'
+ *   'provider-default'     -> use the model's `think` setting
+ *
+ * Requires a reasoning-capable model (e.g. qwen3.5, deepseek-r1, gpt-oss).
+ *
+ * Run: pnpm --filter @examples/node exec tsx src/reasoning-effort-example.ts
+ */
+import { ollama } from 'ai-sdk-ollama';
+import { generateText, streamText } from 'ai';
+import { MODELS } from './model';
+
+// No `think` setting here; the per-call `reasoning` option controls effort.
+const model = ollama(MODELS.QWEN_3_5);
+
+async function generateWith(reasoning: 'none' | 'low' | 'high') {
+  const { text, reasoningText } = await generateText({
+    model,
+    reasoning,
+    prompt: 'What is 12 * 13? Reply with just the number.',
+  });
+  console.log(
+    `  reasoning='${reasoning}' → reasoning chars: ${(reasoningText ?? '').length}, answer: ${text.replace(/\s+/g, ' ').trim().slice(0, 40)}`,
+  );
+}
+
+async function main() {
+  console.log('=== Per-call reasoning effort (v7) ===\n');
+
+  console.log('generateText:');
+  await generateWith('none'); // thinking disabled
+  await generateWith('low'); // light thinking
+  await generateWith('high'); // full thinking
+
+  // The same option works while streaming.
+  console.log('\nstreamText (reasoning="high"):');
+  const stream = streamText({
+    model,
+    reasoning: 'high',
+    prompt: 'Is 91 a prime number? Think, then answer yes or no.',
+  });
+
+  let reasoningChars = 0;
+  for await (const part of stream.fullStream) {
+    if (part.type === 'reasoning-delta') reasoningChars += part.text.length;
+  }
+  console.log(`  streamed reasoning chars: ${reasoningChars}`);
+  console.log(`  answer: ${(await stream.text).replace(/\s+/g, ' ').trim()}`);
+}
+
+main().catch((error) => {
+  console.error('Error:', error);
+  process.exit(1);
+});

--- a/examples/node/src/rerank-example.ts
+++ b/examples/node/src/rerank-example.ts
@@ -1,0 +1,47 @@
+/**
+ * AI SDK v7: `rerank`
+ *
+ * `rerank` is a v7 core function that reorders a list of documents by their
+ * relevance to a query. Ollama has no native rerank endpoint yet, so this
+ * provider ships `ollama.embeddingReranking(...)`, a drop-in `RerankingModel`
+ * that reranks via embedding cosine similarity.
+ *
+ * Run: pnpm --filter @examples/node exec tsx src/rerank-example.ts
+ */
+import { ollama } from 'ai-sdk-ollama';
+import { rerank } from 'ai';
+import { MODELS } from './model';
+
+async function main() {
+  console.log('=== rerank (v7) ===\n');
+
+  const documents = [
+    'The Eiffel Tower is located in Paris, France.',
+    'Machine learning is a subset of AI that learns patterns from data.',
+    'Bananas are a good source of potassium.',
+    'Neural networks are a popular machine learning technique.',
+    'The capital of Japan is Tokyo.',
+  ];
+
+  const { rerankedDocuments, ranking } = await rerank({
+    model: ollama.embeddingReranking(MODELS.NOMIC_EMBED_TEXT),
+    query: 'What is machine learning?',
+    documents,
+    topN: 3,
+  });
+
+  console.log('Query: "What is machine learning?"\n');
+  console.log('Top 3 documents by relevance:');
+  for (const [position, entry] of ranking.entries()) {
+    console.log(
+      `  ${position + 1}. [score ${entry.score.toFixed(4)}] ${entry.document}`,
+    );
+  }
+
+  console.log(`\nrerankedDocuments[0]: ${rerankedDocuments[0]}`);
+}
+
+main().catch((error) => {
+  console.error('Error:', error);
+  process.exit(1);
+});

--- a/examples/node/src/tool-approval-example.ts
+++ b/examples/node/src/tool-approval-example.ts
@@ -1,0 +1,134 @@
+/**
+ * AI SDK v7: Tool Approval (human-in-the-loop)
+ *
+ * v7 replaces the per-tool `needsApproval` property with a `toolApproval`
+ * setting on `generateText`, `streamText`, and `ToolLoopAgent`. The policy
+ * can return:
+ *   - `'approved'`                      → run the tool automatically
+ *   - `{ type: 'denied', reason }`      → block the tool automatically
+ *   - `'user-approval'`                 → pause and ask a human
+ *
+ * When the policy asks for a human decision, the agent emits a
+ * `tool-approval-request` part. You answer with a `ToolApprovalResponse`
+ * (role: 'tool') and call the agent again. To keep this runnable without
+ * typing input, the example decides the human answer in code.
+ *
+ * Run: pnpm --filter @examples/node exec tsx src/tool-approval-example.ts
+ */
+import { ollama } from 'ai-sdk-ollama';
+import {
+  ToolLoopAgent,
+  isStepCount,
+  tool,
+  type ModelMessage,
+  type ToolApprovalResponse,
+} from 'ai';
+import { z } from 'zod';
+import { MODELS } from './model';
+
+const deleteFile = tool({
+  description: 'Delete the file at the given absolute path.',
+  inputSchema: z.object({ path: z.string() }),
+  execute: async ({ path }) => ({ deleted: path }),
+});
+
+const agent = new ToolLoopAgent({
+  model: ollama(MODELS.LLAMA_3_2),
+  instructions:
+    'You delete files using the deleteFile tool. Call deleteFile once for each ' +
+    'path the user lists. If a deletion was not approved, do not retry it. ' +
+    'Report that it was not approved.',
+  tools: { deleteFile },
+  stopWhen: isStepCount(8),
+  // Approval policy: auto-approve scratch files, auto-deny system paths,
+  // and ask a human for everything else.
+  toolApproval: {
+    deleteFile: ({ path }) => {
+      if (path.startsWith('/tmp/')) return 'approved';
+      if (path.startsWith('/etc/') || path.startsWith('/usr/')) {
+        return { type: 'denied', reason: 'protected system path' };
+      }
+      return 'user-approval';
+    },
+  },
+});
+
+// Stand-in for a real prompt to the user. Here: approve files in a home dir.
+function simulateUserDecision(path: string): boolean {
+  return path.includes('/home/');
+}
+
+async function main() {
+  console.log('=== Tool Approval / human-in-the-loop (v7) ===\n');
+
+  const messages: ModelMessage[] = [
+    {
+      role: 'user',
+      content:
+        'Delete these files: /tmp/cache.log, /etc/passwd, and /home/me/notes.txt',
+    },
+  ];
+
+  let approvals: ToolApprovalResponse[] = [];
+
+  for (let round = 0; round < 5; round++) {
+    if (approvals.length > 0) {
+      messages.push({ role: 'tool', content: approvals });
+      approvals = [];
+    }
+
+    const result = await agent.generate({ messages });
+    messages.push(...result.responseMessages);
+
+    let awaitingHuman = false;
+    for (const step of result.steps) {
+      for (const part of step.content) {
+        switch (part.type) {
+          case 'tool-approval-request': {
+            // `isAutomatic` is true for policy-decided requests; we only need
+            // to answer the ones routed to a human ('user-approval').
+            if (!part.isAutomatic && !part.toolCall.dynamic) {
+              const { path } = part.toolCall.input;
+              const approved = simulateUserDecision(path);
+              console.log(
+                `🙋 User asked about deleteFile(${path}) → ${approved ? 'APPROVED' : 'DENIED'}`,
+              );
+              approvals.push({
+                type: 'tool-approval-response',
+                approvalId: part.approvalId,
+                approved,
+              });
+              awaitingHuman = true;
+            }
+            break;
+          }
+          case 'tool-approval-response': {
+            // Emitted for policy-decided (automatic) approvals/denials.
+            if (!part.toolCall.dynamic) {
+              const { path } = part.toolCall.input;
+              console.log(
+                `⚙️  Policy ${part.approved ? 'approved' : 'denied'} deleteFile(${path})` +
+                  (part.reason ? `: ${part.reason}` : ''),
+              );
+            }
+            break;
+          }
+          case 'tool-result': {
+            console.log(`✅ Executed: ${JSON.stringify(part.output)}`);
+            break;
+          }
+        }
+      }
+    }
+
+    if (!awaitingHuman) {
+      console.log(`\nFinal answer:\n${result.text}`);
+      break;
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error('Error:', error);
+  process.exit(1);
+});

--- a/packages/ai-sdk-ollama/README.md
+++ b/packages/ai-sdk-ollama/README.md
@@ -5,14 +5,28 @@
 [![Node.js](https://img.shields.io/badge/Node.js-22+-green.svg)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A Vercel AI SDK v6 provider for Ollama built on the official `ollama` package. Type safe, future proof, with cross provider compatibility and native Ollama features.
+A Vercel AI SDK provider for Ollama built on the official `ollama` package. Type safe, future proof, with cross provider compatibility and native Ollama features.
 
-> **📌 Version Compatibility**: This version (v3+) requires AI SDK v6. If you're using AI SDK v5, please use `ai-sdk-ollama@^2.0.0` instead.
+> **📌 Version compatibility**
+>
+> Each `ai-sdk-ollama` major targets one AI SDK major. Every line stays published on npm, so pick the one that matches your `ai` version:
+>
+> | `ai-sdk-ollama` | `ai` (peer) | Status |
+> | --- | --- | --- |
+> | `4.x` (`@beta`) | `ai@^7` (beta) | Active. New features land here. |
+> | `3.x` | `ai@^6` | Maintenance. Critical fixes only. |
+> | `2.x` | `ai@^5` | Unmaintained. |
+>
+> While AI SDK v7 is in beta, install v4 from the `beta` tag. The v3 line keeps working for AI SDK v6 the whole time. Once AI SDK v7 ships stable, v4 moves to the `latest` tag.
 
 ## Quick Start
 
 ```bash
-npm install ai-sdk-ollama ai@^6.0.0
+# AI SDK v7 (beta)
+npm install ai-sdk-ollama@beta ai@beta
+
+# AI SDK v6 (stable)
+npm install ai-sdk-ollama@^3 ai@^6
 ```
 
 ```typescript

--- a/packages/ai-sdk-ollama/package.json
+++ b/packages/ai-sdk-ollama/package.json
@@ -84,13 +84,13 @@
     "tool-calling"
   ],
   "dependencies": {
-    "@ai-sdk/provider": "^3.0.10",
-    "@ai-sdk/provider-utils": "^4.0.30",
+    "@ai-sdk/provider": "4.0.0-beta.19",
+    "@ai-sdk/provider-utils": "5.0.0-beta.49",
     "jsonrepair": "^3.14.0",
     "ollama": "^0.6.3"
   },
   "peerDependencies": {
-    "ai": "^6.0.197"
+    "ai": ">=7.0.0-beta.179 <8.0.0"
   },
   "devDependencies": {
     "@ai-sdk/test-server": "^1.0.5",

--- a/packages/ai-sdk-ollama/src/index.ts
+++ b/packages/ai-sdk-ollama/src/index.ts
@@ -98,8 +98,9 @@ export {
   stepCountIs,
   hasToolCall,
   type ToolLoopAgentSettings,
-  type ToolLoopAgentOnFinishCallback,
-  type ToolLoopAgentOnStepFinishCallback,
+  // Renamed in AI SDK v7: the agent now reuses the generateText callbacks.
+  type GenerateTextOnFinishCallback,
+  type GenerateTextOnStepFinishCallback,
   type Agent,
   type AgentCallParameters,
   type AgentStreamParameters,

--- a/packages/ai-sdk-ollama/src/models/chat-language-model.test.ts
+++ b/packages/ai-sdk-ollama/src/models/chat-language-model.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { OllamaChatLanguageModel } from './chat-language-model';
 import { OllamaChatSettings } from '../provider';
 import {
-  LanguageModelV3CallOptions,
-  LanguageModelV3StreamPart,
-  LanguageModelV3FunctionTool,
+  LanguageModelV4CallOptions,
+  LanguageModelV4StreamPart,
+  LanguageModelV4FunctionTool,
 } from '@ai-sdk/provider';
 import { Ollama, AbortableAsyncIterator, ChatResponse } from 'ollama';
 import { convertArrayToAsyncIterable } from '@ai-sdk/provider-utils/test';
@@ -54,7 +54,7 @@ describe('OllamaChatLanguageModel', () => {
 
   describe('initialization', () => {
     it('should initialize with correct properties', () => {
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
       expect(model.modelId).toBe('llama3.2');
       expect(model.provider).toBe('ollama');
     });
@@ -101,7 +101,7 @@ describe('OllamaChatLanguageModel', () => {
 
       vi.mocked(mockOllamaClient.chat).mockResolvedValueOnce(mockResponse);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
       };
 
@@ -140,7 +140,7 @@ describe('OllamaChatLanguageModel', () => {
 
       vi.mocked(mockOllamaClient.chat).mockResolvedValueOnce(mockResponse);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
         temperature: 0.7,
         maxOutputTokens: 100,
@@ -190,7 +190,7 @@ describe('OllamaChatLanguageModel', () => {
 
       vi.mocked(mockOllamaClient.chat).mockResolvedValueOnce(mockResponse);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [
           { role: 'user', content: [{ type: 'text', text: 'Generate JSON' }] },
         ],
@@ -231,7 +231,7 @@ describe('OllamaChatLanguageModel', () => {
 
       vi.mocked(mockOllamaClient.chat).mockResolvedValueOnce(mockResponse);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
         tools: [
           {
@@ -296,7 +296,7 @@ describe('OllamaChatLanguageModel', () => {
 
       vi.mocked(mockOllamaClient.chat).mockResolvedValueOnce(mockResponse);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [
           {
             role: 'user',
@@ -393,7 +393,7 @@ describe('OllamaChatLanguageModel', () => {
         .mockResolvedValueOnce(initialResponse)
         .mockResolvedValueOnce(forcedResponse);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [
           {
             role: 'user',
@@ -414,7 +414,7 @@ describe('OllamaChatLanguageModel', () => {
               },
             },
             execute: toolExecute,
-          } as LanguageModelV3FunctionTool & { execute: typeof toolExecute },
+          } as LanguageModelV4FunctionTool & { execute: typeof toolExecute },
         ],
       };
 
@@ -437,7 +437,7 @@ describe('OllamaChatLanguageModel', () => {
       const error = new Error('Connection failed');
       vi.mocked(mockOllamaClient.chat).mockRejectedValueOnce(error);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
       };
 
@@ -466,7 +466,7 @@ describe('OllamaChatLanguageModel', () => {
 
       vi.mocked(mockOllamaClient.chat).mockResolvedValueOnce(mockResponse);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [
           {
             role: 'user',
@@ -527,7 +527,7 @@ describe('OllamaChatLanguageModel', () => {
 
       mockChatStream(mockStreamData);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
       };
 
@@ -625,7 +625,7 @@ describe('OllamaChatLanguageModel', () => {
 
       mockChatStream(mockStreamData);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [
           {
             role: 'user',
@@ -680,7 +680,7 @@ describe('OllamaChatLanguageModel', () => {
       const error = new Error('Stream error');
       vi.mocked(mockOllamaClient.chat).mockRejectedValueOnce(error);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
       };
 
@@ -704,7 +704,7 @@ describe('OllamaChatLanguageModel', () => {
         mockAsyncIterable as unknown as AbortableAsyncIterator<ChatResponse>,
       );
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
         abortSignal: abortController.signal,
       };
@@ -758,7 +758,7 @@ describe('OllamaChatLanguageModel', () => {
 
       vi.mocked(mockOllamaClient.chat).mockResolvedValueOnce(mockResponse);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
       };
 
@@ -812,7 +812,7 @@ describe('OllamaChatLanguageModel', () => {
 
       vi.mocked(mockOllamaClient.chat).mockResolvedValueOnce(mockResponse);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
         temperature: 0.9, // Will be overridden by Ollama setting
         topK: 60, // Will be overridden by Ollama setting
@@ -861,7 +861,7 @@ describe('OllamaChatLanguageModel', () => {
         { client: mockOllamaClient, provider: 'ollama' },
       );
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [
           {
             role: 'user',
@@ -910,7 +910,7 @@ describe('OllamaChatLanguageModel', () => {
         { client: mockOllamaClient, provider: 'ollama' },
       );
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [
           {
             role: 'user',
@@ -975,7 +975,7 @@ describe('OllamaChatLanguageModel', () => {
         { client: mockOllamaClient, provider: 'ollama' },
       );
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [
           {
             role: 'user',
@@ -985,7 +985,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await modelWithReasoning.doStream(options);
-      const chunks: LanguageModelV3StreamPart[] = [];
+      const chunks: LanguageModelV4StreamPart[] = [];
 
       for await (const chunk of stream) {
         chunks.push(chunk);
@@ -1060,7 +1060,7 @@ describe('OllamaChatLanguageModel', () => {
         { client: mockOllamaClient, provider: 'ollama' },
       );
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [
           {
             role: 'user',
@@ -1070,7 +1070,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await modelWithoutReasoning.doStream(options);
-      const chunks: LanguageModelV3StreamPart[] = [];
+      const chunks: LanguageModelV4StreamPart[] = [];
 
       for await (const chunk of stream) {
         chunks.push(chunk);
@@ -1184,7 +1184,7 @@ describe('OllamaChatLanguageModel', () => {
         { client: mockOllamaClient, provider: 'ollama' },
       );
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [
           {
             role: 'user',
@@ -1194,7 +1194,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await modelWithReasoning.doStream(options);
-      const chunks: LanguageModelV3StreamPart[] = [];
+      const chunks: LanguageModelV4StreamPart[] = [];
 
       for await (const chunk of stream) {
         chunks.push(chunk);
@@ -1291,12 +1291,12 @@ describe('OllamaChatLanguageModel', () => {
 
       mockChatStream(mockStreamData);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
       };
 
       const { stream } = await model.doStream(options);
-      const chunks: LanguageModelV3StreamPart[] = [];
+      const chunks: LanguageModelV4StreamPart[] = [];
 
       for await (const chunk of stream) {
         chunks.push(chunk);
@@ -1368,12 +1368,12 @@ describe('OllamaChatLanguageModel', () => {
 
       mockChatStream(mockStreamData);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
       };
 
       const { stream } = await model.doStream(options);
-      const chunks: LanguageModelV3StreamPart[] = [];
+      const chunks: LanguageModelV4StreamPart[] = [];
 
       for await (const chunk of stream) {
         chunks.push(chunk);
@@ -1424,12 +1424,12 @@ describe('OllamaChatLanguageModel', () => {
 
       mockChatStream(mockStreamData);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
       };
 
       const { stream } = await model.doStream(options);
-      const chunks: LanguageModelV3StreamPart[] = [];
+      const chunks: LanguageModelV4StreamPart[] = [];
 
       for await (const chunk of stream) {
         chunks.push(chunk);
@@ -1514,12 +1514,12 @@ describe('OllamaChatLanguageModel', () => {
 
       mockChatStream(mockStreamData);
 
-      const options: LanguageModelV3CallOptions = {
+      const options: LanguageModelV4CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Test' }] }],
       };
 
       const { stream } = await model.doStream(options);
-      const chunks: LanguageModelV3StreamPart[] = [];
+      const chunks: LanguageModelV4StreamPart[] = [];
 
       for await (const chunk of stream) {
         chunks.push(chunk);

--- a/packages/ai-sdk-ollama/src/models/chat-language-model.ts
+++ b/packages/ai-sdk-ollama/src/models/chat-language-model.ts
@@ -1,17 +1,17 @@
 import {
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  LanguageModelV3FinishReason,
-  LanguageModelV3StreamPart,
-  LanguageModelV3Usage,
-  LanguageModelV3Content,
+  LanguageModelV4,
+  LanguageModelV4CallOptions,
+  LanguageModelV4FinishReason,
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+  LanguageModelV4Content,
   JSONValue,
-  LanguageModelV3FunctionTool,
-  LanguageModelV3Prompt,
-  LanguageModelV3TextPart,
+  LanguageModelV4FunctionTool,
+  LanguageModelV4Prompt,
+  LanguageModelV4TextPart,
   JSONSchema7,
   SharedV2ProviderMetadata,
-  SharedV3Warning,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   Ollama,
@@ -43,14 +43,20 @@ import {
   type ObjectGenerationOptions,
 } from '../utils/object-generation-reliability';
 
+/**
+ * The effective Ollama `think` value for a request, derived from the canonical
+ * Ollama `ChatRequest['think']` contract (`boolean | 'high' | 'medium' | 'low'`).
+ */
+type OllamaThink = OllamaChatSettings['think'];
+
 type GenerateResult = {
-  content: LanguageModelV3Content[];
-  finishReason: LanguageModelV3FinishReason;
-  usage: LanguageModelV3Usage;
+  content: LanguageModelV4Content[];
+  finishReason: LanguageModelV4FinishReason;
+  usage: LanguageModelV4Usage;
   providerMetadata?: SharedV2ProviderMetadata;
   request?: { body?: unknown };
   response?: { id?: string; timestamp?: Date; modelId?: string };
-  warnings: SharedV3Warning[];
+  warnings: SharedV4Warning[];
 };
 
 interface ParsedToolCall {
@@ -96,8 +102,8 @@ function buildContent(
   includeReasoning: boolean,
   text: string | undefined,
   toolCalls: ParsedToolCall[],
-): LanguageModelV3Content[] {
-  const content: LanguageModelV3Content[] = [];
+): LanguageModelV4Content[] {
+  const content: LanguageModelV4Content[] = [];
 
   if (reasoning && includeReasoning) {
     content.push({ type: 'reasoning', text: reasoning });
@@ -120,13 +126,13 @@ function buildContent(
 }
 
 /**
- * Create a LanguageModelV3Usage object from token counts.
+ * Create a LanguageModelV4Usage object from token counts.
  * V3 uses structured objects for inputTokens and outputTokens.
  */
 function createUsage(
   inputTokenCount?: number,
   outputTokenCount?: number,
-): LanguageModelV3Usage {
+): LanguageModelV4Usage {
   return {
     inputTokens: {
       total: inputTokenCount,
@@ -142,7 +148,7 @@ function createUsage(
   };
 }
 
-function aggregateUsage(...responses: ChatResponse[]): LanguageModelV3Usage {
+function aggregateUsage(...responses: ChatResponse[]): LanguageModelV4Usage {
   let inputTokens: number | undefined;
   let outputTokens: number | undefined;
 
@@ -174,7 +180,7 @@ function getLatestUserMessage(messages: OllamaMessage[]): string {
 }
 
 function getLatestUserPromptText(
-  prompt: LanguageModelV3Prompt | undefined,
+  prompt: LanguageModelV4Prompt | undefined,
 ): string {
   if (!prompt) {
     return '';
@@ -192,7 +198,7 @@ function getLatestUserPromptText(
       return message.content;
     } else if (Array.isArray(message.content)) {
       const textParts = message.content.filter(
-        (part): part is LanguageModelV3TextPart => part.type === 'text',
+        (part): part is LanguageModelV4TextPart => part.type === 'text',
       );
 
       if (textParts.length > 0) {
@@ -209,8 +215,8 @@ export interface OllamaChatConfig {
   provider: string;
 }
 
-export class OllamaChatLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = 'v3' as const;
+export class OllamaChatLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = 'v4' as const;
 
   // V3 uses supportedUrls with media type patterns as keys
   // Ollama supports images via URLs, files, and base64
@@ -242,7 +248,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
    * This is used internally to auto-detect when structured outputs are needed
    */
   private shouldEnableStructuredOutputs(
-    options: LanguageModelV3CallOptions,
+    options: LanguageModelV4CallOptions,
   ): boolean {
     // Auto-detect: if we have a JSON schema, we need structured outputs
     // This overrides explicit settings to ensure object generation works
@@ -269,12 +275,12 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
     return false;
   }
 
-  private getCallOptions(options: LanguageModelV3CallOptions): {
+  private getCallOptions(options: LanguageModelV4CallOptions): {
     messages: OllamaMessage[];
     options: Record<string, unknown>;
     format?: string | Record<string, unknown>;
     tools?: Tool[];
-    warnings: SharedV3Warning[];
+    warnings: SharedV4Warning[];
     keep_alive?: string | number;
   } {
     const {
@@ -291,7 +297,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       tools,
     } = options;
 
-    const warnings: SharedV3Warning[] = [];
+    const warnings: SharedV4Warning[] = [];
 
     // Auto-detect structured outputs when JSON schema is provided
     const needsStructuredOutputs = this.shouldEnableStructuredOutputs(options);
@@ -426,6 +432,71 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
   }
 
   /**
+   * Resolve the effective Ollama `think` value for a request.
+   *
+   * AI SDK v7 adds a per-call `reasoning` effort option to
+   * `LanguageModelV4CallOptions`. We map it onto Ollama's `think` parameter
+   * (`boolean | 'high' | 'medium' | 'low'`):
+   *
+   * - `'none'`                     -> `false`
+   * - `'minimal'` / `'low'`        -> `'low'`
+   * - `'medium'`                   -> `'medium'`
+   * - `'high'` / `'xhigh'`         -> `'high'`
+   * - `'provider-default'` / unset -> fall back to the `think` provider setting
+   *
+   * The per-call `reasoning` option takes precedence over the model-level
+   * `think` setting, so reasoning effort can vary per request.
+   */
+  private resolveThink(options: LanguageModelV4CallOptions): OllamaThink {
+    switch (options.reasoning) {
+      case 'none': {
+        return false;
+      }
+      case 'minimal':
+      case 'low': {
+        return 'low';
+      }
+      case 'medium': {
+        return 'medium';
+      }
+      case 'high':
+      case 'xhigh': {
+        return 'high';
+      }
+      // 'provider-default', undefined, or any future value: use the model setting.
+      default: {
+        return this.settings.think;
+      }
+    }
+  }
+
+  /**
+   * Assemble the common Ollama chat request envelope shared by every
+   * `client.chat()` call (generate, streaming, tool/object reliability,
+   * forced completion). Callers add the `stream: true | false` literal at the
+   * call site so the Ollama client's streaming overload still resolves.
+   */
+  private buildChatRequest(params: {
+    messages: OllamaMessage[];
+    options: Record<string, unknown>;
+    format?: string | Record<string, unknown>;
+    tools?: Tool[];
+    keep_alive?: string | number;
+    think?: OllamaThink;
+  }) {
+    const { messages, options, format, tools, keep_alive, think } = params;
+    return {
+      model: this.modelId,
+      messages,
+      options,
+      format,
+      ...(tools !== undefined && { tools }),
+      ...(keep_alive !== undefined && { keep_alive }),
+      ...(think !== undefined && { think }),
+    };
+  }
+
+  /**
    * Clean JSON schema for Ollama compatibility by removing complex patterns
    * that cause "fetch failed" errors while preserving basic validation constraints
    */
@@ -490,7 +561,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(
-    options: LanguageModelV3CallOptions,
+    options: LanguageModelV4CallOptions,
   ): Promise<GenerateResult> {
     const {
       messages,
@@ -501,8 +572,10 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       keep_alive,
     } = this.getCallOptions(options);
 
+    const think = this.resolveThink(options);
+
     const functionTools = (options.tools ?? []).filter(
-      (tool): tool is LanguageModelV3FunctionTool => tool.type === 'function',
+      (tool): tool is LanguageModelV4FunctionTool => tool.type === 'function',
     );
 
     // Use reliability features for tool calling when explicitly enabled
@@ -581,16 +654,15 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
     // Regular tool calling (original implementation)
     try {
       const response = (await this.config.client.chat({
-        model: this.modelId,
-        messages,
-        options: ollamaOptions,
-        format,
-        tools,
-        stream: false,
-        ...(keep_alive !== undefined && { keep_alive }),
-        ...(this.settings.think !== undefined && {
-          think: this.settings.think,
+        ...this.buildChatRequest({
+          messages,
+          options: ollamaOptions,
+          format,
+          tools,
+          keep_alive,
+          think,
         }),
+        stream: false,
       })) as ChatResponse;
 
       const text = response.message.content;
@@ -598,10 +670,10 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       const thinking = response.message.thinking;
 
       // Convert content based on whether we have tool calls, reasoning, or text
-      const content: LanguageModelV3Content[] = [];
+      const content: LanguageModelV4Content[] = [];
 
       // Add reasoning content if present and enabled
-      if (thinking && this.settings.think) {
+      if (thinking && think) {
         content.push({ type: 'reasoning', text: thinking });
       }
 
@@ -674,7 +746,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
     messages: OllamaMessage[];
     ollamaOptions: Record<string, unknown>;
     toolResults: Awaited<ReturnType<typeof executeReliableToolCalls>>;
-    originalOptions: LanguageModelV3CallOptions;
+    originalOptions: LanguageModelV4CallOptions;
     format?: string | Record<string, unknown>;
     keep_alive?: string | number;
   }): Promise<{ text: string; response: ChatResponse } | undefined> {
@@ -687,10 +759,12 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       keep_alive,
     } = params;
 
+    const think = this.resolveThink(originalOptions);
+
     let followUpResponse: ChatResponse | undefined;
 
     const followUpModel = {
-      doGenerate: async (callOptions: LanguageModelV3CallOptions) => {
+      doGenerate: async (callOptions: LanguageModelV4CallOptions) => {
         const prompt = callOptions.prompt;
         const followUpPrompt =
           typeof prompt === 'string' ? prompt : JSON.stringify(prompt);
@@ -704,15 +778,14 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
         ];
 
         followUpResponse = (await this.config.client.chat({
-          model: this.modelId,
-          messages: followUpMessages,
-          options: ollamaOptions,
-          format,
-          stream: false,
-          ...(keep_alive !== undefined && { keep_alive }),
-          ...(this.settings.think !== undefined && {
-            think: this.settings.think,
+          ...this.buildChatRequest({
+            messages: followUpMessages,
+            options: ollamaOptions,
+            format,
+            keep_alive,
+            think,
           }),
+          stream: false,
         })) as ChatResponse;
 
         const followUpText = followUpResponse.message.content ?? '';
@@ -723,7 +796,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
                 {
                   type: 'text',
                   text: followUpText,
-                } satisfies LanguageModelV3Content,
+                } satisfies LanguageModelV4Content,
               ]
             : [],
         };
@@ -762,7 +835,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
     ollamaOptions: Record<string, unknown>;
     format?: string | Record<string, unknown>;
     ollamaTools?: Tool[];
-    warnings: SharedV3Warning[];
+    warnings: SharedV4Warning[];
     response: ChatResponse;
     followUpResponse?: ChatResponse;
     parsedToolCalls: ParsedToolCall[];
@@ -773,6 +846,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
     reliable: boolean;
     finalTextOverride?: string;
     keep_alive?: string | number;
+    think?: OllamaThink;
   }): GenerateResult {
     const {
       messages,
@@ -789,6 +863,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       toolResults,
       reliable,
       finalTextOverride,
+      think,
     } = params;
 
     const finalText = finalTextOverride ?? response.message.content ?? '';
@@ -796,7 +871,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
 
     const content = buildContent(
       thinking,
-      Boolean(this.settings.think),
+      Boolean(think),
       finalText,
       parsedToolCalls,
     );
@@ -807,7 +882,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       ? aggregateUsage(response, followUpResponse)
       : aggregateUsage(response);
 
-    const finishReason: LanguageModelV3FinishReason =
+    const finishReason: LanguageModelV4FinishReason =
       mapOllamaFinishReason(finishSource.done_reason) ??
       mapOllamaFinishReason('stop');
 
@@ -886,8 +961,8 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
     ollamaOptions: Record<string, unknown>;
     format?: string | Record<string, unknown>;
     ollamaTools?: Tool[];
-    warnings: SharedV3Warning[];
-    originalOptions: LanguageModelV3CallOptions;
+    warnings: SharedV4Warning[];
+    originalOptions: LanguageModelV4CallOptions;
     toolDefinitions: Record<string, ToolDefinition>;
     reliabilityOptions: ResolvedToolCallingOptions;
     keep_alive?: string | number;
@@ -904,6 +979,8 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       keep_alive,
     } = params;
 
+    const think = this.resolveThink(originalOptions);
+
     const errors: string[] = [];
     let lastResponse: ChatResponse | undefined;
 
@@ -913,16 +990,15 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       attempt++
     ) {
       const response = (await this.config.client.chat({
-        model: this.modelId,
-        messages,
-        options: ollamaOptions,
-        format,
-        tools: ollamaTools,
-        stream: false,
-        ...(keep_alive !== undefined && { keep_alive }),
-        ...(this.settings.think !== undefined && {
-          think: this.settings.think,
+        ...this.buildChatRequest({
+          messages,
+          options: ollamaOptions,
+          format,
+          tools: ollamaTools,
+          keep_alive,
+          think,
         }),
+        stream: false,
       })) as ChatResponse;
 
       lastResponse = response;
@@ -945,6 +1021,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
           errors,
           reliable: true,
           keep_alive,
+          think,
         });
       }
 
@@ -1025,6 +1102,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
               reliable: true,
               finalTextOverride: followUpData.text,
               keep_alive,
+              think,
             });
           }
 
@@ -1064,6 +1142,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
         errors,
         reliable: true,
         keep_alive,
+        think,
       });
     }
 
@@ -1077,8 +1156,8 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
     ollamaOptions: Record<string, unknown>;
     format?: string | Record<string, unknown>;
     tools?: Tool[];
-    warnings: SharedV3Warning[];
-    originalOptions: LanguageModelV3CallOptions;
+    warnings: SharedV4Warning[];
+    originalOptions: LanguageModelV4CallOptions;
     schema: JSONSchema7;
     objectOptions: ObjectGenerationOptions &
       Required<
@@ -1099,10 +1178,13 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       format,
       tools,
       warnings,
+      originalOptions,
       schema,
       objectOptions,
       keep_alive,
     } = params;
+
+    const think = this.resolveThink(originalOptions);
 
     const errors: string[] = [];
     let lastResponse: ChatResponse | undefined;
@@ -1110,16 +1192,15 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
     for (let attempt = 1; attempt <= objectOptions.maxRetries; attempt++) {
       try {
         const response = (await this.config.client.chat({
-          model: this.modelId,
-          messages,
-          options: ollamaOptions,
-          format,
-          tools,
-          stream: false,
-          ...(keep_alive !== undefined && { keep_alive }),
-          ...(this.settings.think !== undefined && {
-            think: this.settings.think,
+          ...this.buildChatRequest({
+            messages,
+            options: ollamaOptions,
+            format,
+            tools,
+            keep_alive,
+            think,
           }),
+          stream: false,
         })) as ChatResponse;
 
         lastResponse = response;
@@ -1219,7 +1300,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
     ollamaOptions: Record<string, unknown>;
     format?: string | Record<string, unknown>;
     tools?: Tool[];
-    warnings: SharedV3Warning[];
+    warnings: SharedV4Warning[];
     response: ChatResponse;
     text: string;
     validatedObject: unknown;
@@ -1237,9 +1318,9 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       params;
 
     // For object generation, we return the validated text as content
-    const content: LanguageModelV3Content[] = [{ type: 'text', text }];
+    const content: LanguageModelV4Content[] = [{ type: 'text', text }];
 
-    const usage: LanguageModelV3Usage = createUsage(
+    const usage: LanguageModelV4Usage = createUsage(
       response.prompt_eval_count ?? undefined,
       response.eval_count ?? undefined,
     );
@@ -1247,7 +1328,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
     const finishReason =
       (mapOllamaFinishReason(
         response.done_reason,
-      ) as LanguageModelV3FinishReason) ?? 'stop';
+      ) as LanguageModelV4FinishReason) ?? 'stop';
 
     const providerDetails: Record<string, JSONValue> = {
       model: response.model,
@@ -1300,8 +1381,8 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
     };
   }
 
-  async doStream(options: LanguageModelV3CallOptions): Promise<{
-    stream: ReadableStream<LanguageModelV3StreamPart>;
+  async doStream(options: LanguageModelV4CallOptions): Promise<{
+    stream: ReadableStream<LanguageModelV4StreamPart>;
     request?: { body?: unknown };
     response?: { headers?: Record<string, string> };
   }> {
@@ -1314,29 +1395,30 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
       keep_alive,
     } = this.getCallOptions(options);
 
+    const think = this.resolveThink(options);
+
     try {
       const stream = await this.config.client.chat({
-        model: this.modelId,
-        messages,
-        options: ollamaOptions,
-        format,
-        tools,
-        stream: true,
-        ...(keep_alive !== undefined && { keep_alive }),
-        ...(this.settings.think !== undefined && {
-          think: this.settings.think,
+        ...this.buildChatRequest({
+          messages,
+          options: ollamaOptions,
+          format,
+          tools,
+          keep_alive,
+          think,
         }),
+        stream: true,
       });
 
-      let usage: LanguageModelV3Usage = createUsage();
-      let finishReason: LanguageModelV3FinishReason =
+      let usage: LanguageModelV4Usage = createUsage();
+      let finishReason: LanguageModelV4FinishReason =
         mapOllamaFinishReason(null);
 
       // Track if we've emitted stream-start
       let streamStartEmitted = false;
 
       // Capture settings for use in transform function
-      const reasoningEnabled = this.settings.think;
+      const reasoningEnabled = think;
 
       // Track text streaming state for UI message compatibility
       let textStreamStarted = false;
@@ -1351,7 +1433,7 @@ export class OllamaChatLanguageModel implements LanguageModelV3 {
 
       const transformStream = new TransformStream<
         ChatResponse,
-        LanguageModelV3StreamPart
+        LanguageModelV4StreamPart
       >({
         async transform(chunk: ChatResponse, controller) {
           // Emit stream-start with warnings on first chunk

--- a/packages/ai-sdk-ollama/src/models/embedding-model.test.ts
+++ b/packages/ai-sdk-ollama/src/models/embedding-model.test.ts
@@ -24,7 +24,7 @@ describe('OllamaEmbeddingModel', () => {
 
   describe('initialization', () => {
     it('should initialize with correct properties', () => {
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
       expect(model.modelId).toBe('nomic-embed-text');
       expect(model.provider).toBe('ollama');
       expect(model.maxEmbeddingsPerCall).toBe(2048);

--- a/packages/ai-sdk-ollama/src/models/embedding-model.ts
+++ b/packages/ai-sdk-ollama/src/models/embedding-model.ts
@@ -1,9 +1,9 @@
 import {
-  EmbeddingModelV3,
-  EmbeddingModelV3Embedding,
-  SharedV3ProviderMetadata,
-  SharedV3ProviderOptions,
-  SharedV3Warning,
+  EmbeddingModelV4,
+  EmbeddingModelV4Embedding,
+  SharedV4ProviderMetadata,
+  SharedV4ProviderOptions,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import { Ollama, type EmbedResponse } from 'ollama';
 import { OllamaEmbeddingSettings } from '../provider';
@@ -14,8 +14,8 @@ export interface OllamaEmbeddingConfig {
   provider: string;
 }
 
-export class OllamaEmbeddingModel implements EmbeddingModelV3 {
-  readonly specificationVersion = 'v3' as const;
+export class OllamaEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = 'v4' as const;
   readonly modelId: string;
   readonly maxEmbeddingsPerCall = 2048;
   readonly supportsParallelCalls = true;
@@ -35,14 +35,14 @@ export class OllamaEmbeddingModel implements EmbeddingModelV3 {
   async doEmbed(params: {
     values: string[];
     abortSignal?: AbortSignal;
-    providerOptions?: SharedV3ProviderOptions;
+    providerOptions?: SharedV4ProviderOptions;
     headers?: Record<string, string | undefined>;
   }): Promise<{
-    embeddings: EmbeddingModelV3Embedding[];
+    embeddings: EmbeddingModelV4Embedding[];
     usage?: { tokens: number };
-    providerMetadata?: SharedV3ProviderMetadata;
+    providerMetadata?: SharedV4ProviderMetadata;
     response?: { headers?: Record<string, string>; body?: unknown };
-    warnings: SharedV3Warning[];
+    warnings: SharedV4Warning[];
   }> {
     const { values, abortSignal } = params;
     if (values.length > this.maxEmbeddingsPerCall) {
@@ -57,7 +57,7 @@ export class OllamaEmbeddingModel implements EmbeddingModelV3 {
     }
 
     try {
-      const embeddings: EmbeddingModelV3Embedding[] = [];
+      const embeddings: EmbeddingModelV4Embedding[] = [];
       let totalTokens = 0;
 
       // Ollama's embed API currently only supports single prompts

--- a/packages/ai-sdk-ollama/src/models/embedding-reranking-model.test.ts
+++ b/packages/ai-sdk-ollama/src/models/embedding-reranking-model.test.ts
@@ -23,9 +23,9 @@ describe('OllamaEmbeddingRerankingModel', () => {
     });
 
   describe('constructor', () => {
-    it('should set specificationVersion to v3', () => {
+    it('should set specificationVersion to v4', () => {
       const model = createModel();
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
     });
 
     it('should set modelId correctly', () => {

--- a/packages/ai-sdk-ollama/src/models/embedding-reranking-model.ts
+++ b/packages/ai-sdk-ollama/src/models/embedding-reranking-model.ts
@@ -1,7 +1,7 @@
 import {
-  RerankingModelV3,
-  RerankingModelV3CallOptions,
-  SharedV3Warning,
+  RerankingModelV4,
+  RerankingModelV4CallOptions,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import { Ollama } from 'ollama';
 import { cosineSimilarity } from '../utils/cosine-similarity';
@@ -66,8 +66,8 @@ export interface OllamaEmbeddingRerankingSettings {
  * // Documents sorted by relevance to the query
  * ```
  */
-export class OllamaEmbeddingRerankingModel implements RerankingModelV3 {
-  readonly specificationVersion = 'v3' as const;
+export class OllamaEmbeddingRerankingModel implements RerankingModelV4 {
+  readonly specificationVersion = 'v4' as const;
   readonly modelId: string;
 
   private readonly config: OllamaEmbeddingRerankingConfig;
@@ -150,10 +150,10 @@ export class OllamaEmbeddingRerankingModel implements RerankingModelV3 {
     documents,
     query,
     topN,
-  }: RerankingModelV3CallOptions): Promise<
-    Awaited<ReturnType<RerankingModelV3['doRerank']>>
+  }: RerankingModelV4CallOptions): Promise<
+    Awaited<ReturnType<RerankingModelV4['doRerank']>>
   > {
-    const warnings: SharedV3Warning[] = [];
+    const warnings: SharedV4Warning[] = [];
 
     // Convert documents to strings
     let documentValues: string[];

--- a/packages/ai-sdk-ollama/src/models/image-model.ts
+++ b/packages/ai-sdk-ollama/src/models/image-model.ts
@@ -1,10 +1,10 @@
 import type {
-  ImageModelV3,
-  ImageModelV3CallOptions,
-  ImageModelV3ProviderMetadata,
-  ImageModelV3Usage,
+  ImageModelV4,
+  ImageModelV4CallOptions,
+  ImageModelV4ProviderMetadata,
+  ImageModelV4Usage,
 } from '@ai-sdk/provider';
-import type { SharedV3Warning } from '@ai-sdk/provider';
+import type { SharedV4Warning } from '@ai-sdk/provider';
 import { parseProviderOptions } from '@ai-sdk/provider-utils';
 import { z } from 'zod';
 import { OllamaError } from '../utils/ollama-error';
@@ -23,12 +23,12 @@ export interface OllamaImageModelConfig {
 }
 
 /**
- * Ollama image generation model (ImageModelV3).
+ * Ollama image generation model (ImageModelV4).
  * Uses POST /api/generate with image models (e.g. x/z-image-turbo, x/flux2-klein).
  * Experimental; see https://ollama.com/blog/image-generation
  */
-export class OllamaImageModel implements ImageModelV3 {
-  readonly specificationVersion = 'v3' as const;
+export class OllamaImageModel implements ImageModelV4 {
+  readonly specificationVersion = 'v4' as const;
   readonly provider: string;
   readonly modelId: string;
   readonly maxImagesPerCall = 1;
@@ -41,16 +41,16 @@ export class OllamaImageModel implements ImageModelV3 {
     this.provider = config.provider;
   }
 
-  async doGenerate(options: ImageModelV3CallOptions): Promise<{
+  async doGenerate(options: ImageModelV4CallOptions): Promise<{
     images: Array<string>;
-    warnings: Array<SharedV3Warning>;
+    warnings: Array<SharedV4Warning>;
     response: {
       timestamp: Date;
       modelId: string;
       headers: Record<string, string> | undefined;
     };
-    usage?: ImageModelV3Usage;
-    providerMetadata?: ImageModelV3ProviderMetadata;
+    usage?: ImageModelV4Usage;
+    providerMetadata?: ImageModelV4ProviderMetadata;
   }> {
     const {
       prompt,

--- a/packages/ai-sdk-ollama/src/models/reranking-model.test.ts
+++ b/packages/ai-sdk-ollama/src/models/reranking-model.test.ts
@@ -21,9 +21,9 @@ describe('OllamaRerankingModel', () => {
     });
 
   describe('constructor', () => {
-    it('should set specificationVersion to v3', () => {
+    it('should set specificationVersion to v4', () => {
       const model = createModel();
-      expect(model.specificationVersion).toBe('v3');
+      expect(model.specificationVersion).toBe('v4');
     });
 
     it('should set modelId correctly', () => {

--- a/packages/ai-sdk-ollama/src/models/reranking-model.ts
+++ b/packages/ai-sdk-ollama/src/models/reranking-model.ts
@@ -1,7 +1,7 @@
 import {
-  RerankingModelV3,
-  RerankingModelV3CallOptions,
-  SharedV3Warning,
+  RerankingModelV4,
+  RerankingModelV4CallOptions,
+  SharedV4Warning,
 } from '@ai-sdk/provider';
 import {
   combineHeaders,
@@ -132,8 +132,8 @@ const ollamaFailedResponseHandler = createJsonErrorResponseHandler({
  * });
  * ```
  */
-export class OllamaRerankingModel implements RerankingModelV3 {
-  readonly specificationVersion = 'v3' as const;
+export class OllamaRerankingModel implements RerankingModelV4 {
+  readonly specificationVersion = 'v4' as const;
   readonly modelId: string;
 
   private readonly config: OllamaRerankingConfig;
@@ -160,10 +160,10 @@ export class OllamaRerankingModel implements RerankingModelV3 {
     topN,
     abortSignal,
     providerOptions,
-  }: RerankingModelV3CallOptions): Promise<
-    Awaited<ReturnType<RerankingModelV3['doRerank']>>
+  }: RerankingModelV4CallOptions): Promise<
+    Awaited<ReturnType<RerankingModelV4['doRerank']>>
   > {
-    const warnings: SharedV3Warning[] = [];
+    const warnings: SharedV4Warning[] = [];
 
     // Parse provider options
     const rerankingOptions = await parseProviderOptions({

--- a/packages/ai-sdk-ollama/src/provider.browser.ts
+++ b/packages/ai-sdk-ollama/src/provider.browser.ts
@@ -191,7 +191,7 @@ export function createOllama(
   };
 
   provider.tools = toolsWithClient;
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.embeddingModel = createEmbeddingModel;
 
   return provider;

--- a/packages/ai-sdk-ollama/src/provider.ts
+++ b/packages/ai-sdk-ollama/src/provider.ts
@@ -1,8 +1,8 @@
 import {
-  LanguageModelV3,
-  EmbeddingModelV3,
-  RerankingModelV3,
-  ProviderV3,
+  LanguageModelV4,
+  EmbeddingModelV4,
+  RerankingModelV4,
+  ProviderV4,
 } from '@ai-sdk/provider';
 import {
   Ollama,
@@ -77,16 +77,16 @@ export interface OllamaProviderSettings extends Pick<
   client?: Ollama;
 }
 
-export interface OllamaProvider extends ProviderV3 {
+export interface OllamaProvider extends ProviderV4 {
   /**
    * Create a language model instance
    */
-  (modelId: string, settings?: OllamaChatSettings): LanguageModelV3;
+  (modelId: string, settings?: OllamaChatSettings): LanguageModelV4;
 
   /**
    * Create a language model instance with the `chat` method
    */
-  chat(modelId: string, settings?: OllamaChatSettings): LanguageModelV3;
+  chat(modelId: string, settings?: OllamaChatSettings): LanguageModelV4;
 
   /**
    * Create a language model instance with the `languageModel` method
@@ -94,7 +94,7 @@ export interface OllamaProvider extends ProviderV3 {
   languageModel(
     modelId: string,
     settings?: OllamaChatSettings,
-  ): LanguageModelV3;
+  ): LanguageModelV4;
 
   /**
    * Create an embedding model instance
@@ -102,7 +102,7 @@ export interface OllamaProvider extends ProviderV3 {
   embedding(
     modelId: string,
     settings?: OllamaEmbeddingSettings,
-  ): EmbeddingModelV3;
+  ): EmbeddingModelV4;
 
   /**
    * Create an embedding model instance with the `textEmbedding` method
@@ -110,7 +110,7 @@ export interface OllamaProvider extends ProviderV3 {
   textEmbedding(
     modelId: string,
     settings?: OllamaEmbeddingSettings,
-  ): EmbeddingModelV3;
+  ): EmbeddingModelV4;
 
   /**
    * Create an embedding model instance with the `textEmbeddingModel` method
@@ -118,7 +118,7 @@ export interface OllamaProvider extends ProviderV3 {
   textEmbeddingModel(
     modelId: string,
     settings?: OllamaEmbeddingSettings,
-  ): EmbeddingModelV3;
+  ): EmbeddingModelV4;
 
   /**
    * Create a reranking model instance
@@ -126,7 +126,7 @@ export interface OllamaProvider extends ProviderV3 {
   reranking(
     modelId: string,
     settings?: OllamaRerankingSettings,
-  ): RerankingModelV3;
+  ): RerankingModelV4;
 
   /**
    * Create a reranking model instance with the `rerankingModel` method
@@ -138,7 +138,7 @@ export interface OllamaProvider extends ProviderV3 {
   rerankingModel(
     modelId: string,
     settings?: OllamaRerankingSettings,
-  ): RerankingModelV3;
+  ): RerankingModelV4;
 
   /**
    * Create an embedding-based reranking model (RECOMMENDED - working now)
@@ -162,7 +162,7 @@ export interface OllamaProvider extends ProviderV3 {
   embeddingReranking(
     modelId: string,
     settings?: OllamaEmbeddingRerankingSettings,
-  ): RerankingModelV3;
+  ): RerankingModelV4;
 
   /**
    * Ollama-specific tools that leverage web search capabilities
@@ -469,7 +469,7 @@ export function createOllama(
   };
 
   provider.tools = toolsWithClient;
-  provider.specificationVersion = 'v3' as const;
+  provider.specificationVersion = 'v4' as const;
   provider.embeddingModel = createEmbeddingModel;
 
   return provider;

--- a/packages/ai-sdk-ollama/src/tool/web-fetch.test.ts
+++ b/packages/ai-sdk-ollama/src/tool/web-fetch.test.ts
@@ -38,7 +38,7 @@ describe('webFetch', () => {
     const tool = webFetch({ client: mockClient });
     const result = await tool.execute!(
       { url: 'https://example.com' },
-      { toolCallId: 'test', messages: [], abortSignal: undefined },
+      { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
     );
 
     expect(mockWebFetch).toHaveBeenCalledWith({ url: 'https://example.com' });
@@ -65,7 +65,7 @@ describe('webFetch', () => {
     const tool = webFetch({ client: mockClient, maxContentLength: 100 });
     const result = await tool.execute!(
       { url: 'https://example.com/long-article' },
-      { toolCallId: 'test', messages: [], abortSignal: undefined },
+      { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
     );
 
     expect((result as any).content).toHaveLength(124); // 100 chars + "\n\n[Content truncated...]"
@@ -79,7 +79,7 @@ describe('webFetch', () => {
     await expect(
       tool.execute!(
         { url: 'https://example.com' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined },
+        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
       ),
     ).rejects.toThrow(OllamaError);
   });
@@ -90,7 +90,7 @@ describe('webFetch', () => {
     const tool = webFetch({ client: mockClient });
     const result = await tool.execute!(
       { url: 'https://example.com/not-found' },
-      { toolCallId: 'test', messages: [], abortSignal: undefined },
+      { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
     );
 
     expect(result).toEqual(
@@ -136,7 +136,7 @@ describe('webFetch', () => {
       const tool = webFetch({ client: mockClient });
       const result = await tool.execute!(
         { url: 'https://example.com' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined },
+        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
       );
 
       expect((result as any).error).toBe(testCase.expectedMessage);
@@ -152,7 +152,7 @@ describe('webFetch', () => {
     const tool = webFetch({ client: mockClient });
     const result = await tool.execute!(
       { url: 'https://example.com' },
-      { toolCallId: 'test', messages: [], abortSignal: undefined },
+      { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
     );
 
     expect(result).toEqual({
@@ -169,7 +169,7 @@ describe('webFetch', () => {
     const tool = webFetch({ client: mockClient, timeout: 5000 });
     await tool.execute!(
       { url: 'https://example.com' },
-      { toolCallId: 'test', messages: [], abortSignal: undefined },
+      { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
     );
 
     expect(mockWebFetch).toHaveBeenCalledWith({
@@ -187,7 +187,12 @@ describe('webFetch', () => {
     const tool = webFetch({ client: mockClient });
     const result = await tool.execute!(
       { url: 'https://example.com' },
-      { toolCallId: 'test', messages: [], abortSignal: abortController.signal },
+      {
+        toolCallId: 'test',
+        messages: [],
+        abortSignal: abortController.signal,
+        context: {},
+      },
     );
 
     expect((result as any).error).toBe('Web fetch request was cancelled.');
@@ -217,7 +222,7 @@ describe('webFetch', () => {
     const tool = webFetch({ client: mockClient });
     const result = await tool.execute!(
       { url: 'https://example.com' },
-      { toolCallId: 'test', messages: [], abortSignal: undefined },
+      { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
     );
 
     expect((result as any).content).toHaveLength(10_024); // 10_000 + "\n\n[Content truncated...]"

--- a/packages/ai-sdk-ollama/src/tool/web-fetch.ts
+++ b/packages/ai-sdk-ollama/src/tool/web-fetch.ts
@@ -91,11 +91,14 @@ export type WebFetchOutput = {
  * ```
  */
 export function webFetch(options: WebFetchToolOptions = {}) {
-  return tool<WebFetchInput, WebFetchOutput>({
+  return tool({
     description:
       'Fetch and read content from a specific web URL. Use this to retrieve the full text content of web pages, articles, documentation, or any publicly accessible web content for analysis or summarization.',
     inputSchema: webFetchInputSchema,
-    execute: async (input, context) => {
+    execute: async (
+      input: WebFetchInput,
+      context: { abortSignal?: AbortSignal },
+    ): Promise<WebFetchOutput> => {
       const abortSignal = context?.abortSignal;
       const client = options.client;
       if (!client) {

--- a/packages/ai-sdk-ollama/src/tool/web-search.test.ts
+++ b/packages/ai-sdk-ollama/src/tool/web-search.test.ts
@@ -42,7 +42,7 @@ describe('webSearch', () => {
     const tool = webSearch({ client: mockClient });
     const result = await tool.execute!(
       { query: 'AI developments' },
-      { toolCallId: 'test', messages: [], abortSignal: undefined },
+      { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
     );
 
     expect(mockWebSearch).toHaveBeenCalledWith({
@@ -65,7 +65,7 @@ describe('webSearch', () => {
     const tool = webSearch({ client: mockClient });
     await tool.execute!(
       { query: 'test query', maxResults: 8 },
-      { toolCallId: 'test', messages: [], abortSignal: undefined },
+      { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
     );
 
     expect(mockWebSearch).toHaveBeenCalledWith({
@@ -80,7 +80,7 @@ describe('webSearch', () => {
     const tool = webSearch({ client: mockClient });
     await tool.execute!(
       { query: 'test query', maxResults: 50 },
-      { toolCallId: 'test', messages: [], abortSignal: undefined },
+      { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
     );
 
     expect(mockWebSearch).toHaveBeenCalledWith({
@@ -95,7 +95,7 @@ describe('webSearch', () => {
     await expect(
       tool.execute!(
         { query: 'test query' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined },
+        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
       ),
     ).rejects.toThrow(OllamaError);
   });
@@ -108,7 +108,7 @@ describe('webSearch', () => {
     await expect(
       tool.execute!(
         { query: 'test query' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined },
+        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
       ),
     ).rejects.toThrow(OllamaError);
   });
@@ -121,7 +121,7 @@ describe('webSearch', () => {
     await expect(
       tool.execute!(
         { query: 'test query' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined },
+        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
       ),
     ).rejects.toThrow(OllamaError);
   });
@@ -134,7 +134,7 @@ describe('webSearch', () => {
     await expect(
       tool.execute!(
         { query: 'test query' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined },
+        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
       ),
     ).rejects.toThrow(OllamaError);
   });
@@ -151,7 +151,7 @@ describe('webSearch', () => {
     const tool = webSearch({ client: mockClient });
     const result = await tool.execute!(
       { query: 'test query' },
-      { toolCallId: 'test', messages: [], abortSignal: undefined },
+      { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
     );
 
     expect((result as any).results).toEqual(expect.any(Array));
@@ -163,7 +163,7 @@ describe('webSearch', () => {
     const tool = webSearch({ client: mockClient, timeout: 5000 });
     await tool.execute!(
       { query: 'test query' },
-      { toolCallId: 'test', messages: [], abortSignal: undefined },
+      { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
     );
 
     expect(mockWebSearch).toHaveBeenCalledWith({

--- a/packages/ai-sdk-ollama/src/tool/web-search.ts
+++ b/packages/ai-sdk-ollama/src/tool/web-search.ts
@@ -112,11 +112,14 @@ function hasWebSearch(client: unknown): client is {
 }
 
 export function webSearch(options: WebSearchToolOptions = {}) {
-  return tool<WebSearchInput, WebSearchOutput>({
+  return tool({
     description:
       'Search the web for current information about any topic. Use this when you need up-to-date information, recent news, current statistics, or real-time data that may not be in your training data.',
     inputSchema: webSearchInputSchema,
-    execute: async (input, { abortSignal }) => {
+    execute: async (
+      input: WebSearchInput,
+      { abortSignal }: { abortSignal?: AbortSignal },
+    ): Promise<WebSearchOutput> => {
       const client = options.client;
       if (!client) {
         throw new OllamaError({

--- a/packages/ai-sdk-ollama/src/utils/convert-to-ollama-messages.test.ts
+++ b/packages/ai-sdk-ollama/src/utils/convert-to-ollama-messages.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { convertToOllamaChatMessages } from './convert-to-ollama-messages';
-import { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { LanguageModelV4Prompt } from '@ai-sdk/provider';
 
 describe('convertToOllamaChatMessages', () => {
   describe('system messages', () => {
     it('should convert system message', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'system',
           content: 'You are a helpful assistant.',
@@ -25,7 +25,7 @@ describe('convertToOllamaChatMessages', () => {
 
   describe('user messages', () => {
     it('should convert simple user message', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'user',
           content: [{ type: 'text', text: 'Hello, how are you?' }],
@@ -43,7 +43,7 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should convert user message with text parts', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'user',
           content: [
@@ -64,14 +64,14 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should convert user message with image URL', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'user',
           content: [
             { type: 'text', text: 'What is in this image?' },
             {
               type: 'file',
-              data: new URL('https://example.com/image.jpg'),
+              data: { type: 'url', url: new URL('https://example.com/image.jpg') },
               mediaType: 'image/jpeg',
             },
           ],
@@ -90,14 +90,14 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should convert user message with base64 image string', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'user',
           content: [
             { type: 'text', text: 'Describe this image' },
             {
               type: 'file',
-              data: 'data:image/jpeg;base64,/9j/4AAQ...',
+              data: { type: 'data', data: 'data:image/jpeg;base64,/9j/4AAQ...' },
               mediaType: 'image/jpeg',
             },
           ],
@@ -117,12 +117,16 @@ describe('convertToOllamaChatMessages', () => {
 
     it('should convert user message with Uint8Array image', () => {
       const imageData = new Uint8Array([255, 216, 255, 224]); // JPEG header
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'user',
           content: [
             { type: 'text', text: 'Analyze this image' },
-            { type: 'file', data: imageData, mediaType: 'image/jpeg' },
+            {
+              type: 'file',
+              data: { type: 'data', data: imageData },
+              mediaType: 'image/jpeg',
+            },
           ],
         },
       ];
@@ -139,19 +143,22 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should convert user message with multiple images', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'user',
           content: [
             { type: 'text', text: 'Compare these images' },
             {
               type: 'file',
-              data: new URL('https://example.com/image1.jpg'),
+              data: {
+                type: 'url',
+                url: new URL('https://example.com/image1.jpg'),
+              },
               mediaType: 'image/jpeg',
             },
             {
               type: 'file',
-              data: 'data:image/png;base64,iVBOR...',
+              data: { type: 'data', data: 'data:image/png;base64,iVBOR...' },
               mediaType: 'image/png',
             },
           ],
@@ -170,13 +177,13 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should handle user message with only images', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'user',
           content: [
             {
               type: 'file',
-              data: new URL('https://example.com/image.jpg'),
+              data: { type: 'url', url: new URL('https://example.com/image.jpg') },
               mediaType: 'image/jpeg',
             },
           ],
@@ -197,7 +204,7 @@ describe('convertToOllamaChatMessages', () => {
 
   describe('assistant messages', () => {
     it('should convert simple assistant message', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'assistant',
           content: [{ type: 'text', text: 'I am doing well, thank you!' }],
@@ -215,7 +222,7 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should convert assistant message with text parts', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'assistant',
           content: [
@@ -236,7 +243,7 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should convert assistant message with tool calls', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'assistant',
           content: [
@@ -272,7 +279,7 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should convert assistant message with multiple tool calls', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'assistant',
           content: [
@@ -321,7 +328,7 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should repair malformed tool-call JSON via parseToolArguments', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'assistant',
           content: [
@@ -356,7 +363,7 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should handle empty assistant message', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'assistant',
           content: [],
@@ -376,7 +383,7 @@ describe('convertToOllamaChatMessages', () => {
 
   describe('tool messages', () => {
     it('should convert tool message to user message', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'tool',
           content: [
@@ -405,7 +412,7 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should handle tool message with string result', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'tool',
           content: [
@@ -431,7 +438,7 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should handle tool result with output type content (text only)', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'tool',
           content: [
@@ -465,7 +472,7 @@ describe('convertToOllamaChatMessages', () => {
     it('should handle tool result with output type content (image-data)', () => {
       const base64Png =
         'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'tool',
           content: [
@@ -477,8 +484,8 @@ describe('convertToOllamaChatMessages', () => {
                 type: 'content',
                 value: [
                   {
-                    type: 'image-data',
-                    data: base64Png,
+                    type: 'file',
+                    data: { type: 'data', data: base64Png },
                     mediaType: 'image/png',
                   },
                 ],
@@ -502,7 +509,7 @@ describe('convertToOllamaChatMessages', () => {
 
     it('should handle tool result with output type content (text + image-data)', () => {
       const base64Png = '/9j/4AAQ';
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'tool',
           content: [
@@ -515,8 +522,8 @@ describe('convertToOllamaChatMessages', () => {
                 value: [
                   { type: 'text', text: 'Caption: A red pixel.' },
                   {
-                    type: 'image-data',
-                    data: base64Png,
+                    type: 'file',
+                    data: { type: 'data', data: base64Png },
                     mediaType: 'image/jpeg',
                   },
                 ],
@@ -539,7 +546,7 @@ describe('convertToOllamaChatMessages', () => {
     });
 
     it('should handle tool result with output type content (image-url)', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'tool',
           content: [
@@ -551,8 +558,12 @@ describe('convertToOllamaChatMessages', () => {
                 type: 'content',
                 value: [
                   {
-                    type: 'image-url',
-                    url: 'https://example.com/image.png',
+                    type: 'file',
+                    data: {
+                      type: 'url',
+                      url: new URL('https://example.com/image.png'),
+                    },
+                    mediaType: 'image/png',
                   },
                 ],
               },
@@ -576,7 +587,7 @@ describe('convertToOllamaChatMessages', () => {
     it('should handle tool result with output type content (file-data image)', () => {
       const base64Png =
         'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'tool',
           content: [
@@ -588,8 +599,8 @@ describe('convertToOllamaChatMessages', () => {
                 type: 'content',
                 value: [
                   {
-                    type: 'file-data',
-                    data: base64Png,
+                    type: 'file',
+                    data: { type: 'data', data: base64Png },
                     mediaType: 'image/png',
                   },
                 ],
@@ -614,7 +625,7 @@ describe('convertToOllamaChatMessages', () => {
 
   describe('complex conversations', () => {
     it('should convert complete conversation', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'system',
           content: 'You are a helpful assistant.',
@@ -714,20 +725,20 @@ describe('convertToOllamaChatMessages', () => {
 
   describe('edge cases', () => {
     it('should handle empty prompt', () => {
-      const prompt: LanguageModelV3Prompt = [];
+      const prompt: LanguageModelV4Prompt = [];
       const result = convertToOllamaChatMessages(prompt);
       expect(result).toEqual([]);
     });
 
     it('should handle mixed content types properly', () => {
-      const prompt: LanguageModelV3Prompt = [
+      const prompt: LanguageModelV4Prompt = [
         {
           role: 'user',
           content: [
             { type: 'text', text: 'Hello' },
             {
               type: 'file',
-              data: 'data:image/jpeg;base64,abc123',
+              data: { type: 'data', data: 'data:image/jpeg;base64,abc123' },
               mediaType: 'image/jpeg',
             },
             { type: 'text', text: 'World' },
@@ -755,7 +766,11 @@ describe('convertToOllamaChatMessages', () => {
         role: 'user',
         content: [
           { type: 'text', text: 'Analyze this Uint8Array image' },
-          { type: 'file', data: imageData, mediaType: 'image/jpeg' },
+          {
+            type: 'file',
+            data: { type: 'data', data: imageData },
+            mediaType: 'image/jpeg',
+          },
         ],
       },
     ]);
@@ -776,7 +791,11 @@ describe('convertToOllamaChatMessages', () => {
         role: 'user',
         content: [
           { type: 'text', text: 'Analyze this Buffer image' },
-          { type: 'file', data: imageData, mediaType: 'image/jpeg' },
+          {
+            type: 'file',
+            data: { type: 'data', data: imageData },
+            mediaType: 'image/jpeg',
+          },
         ],
       },
     ]);
@@ -797,17 +816,20 @@ describe('convertToOllamaChatMessages', () => {
           { type: 'text', text: 'Compare these different image formats' },
           {
             type: 'file',
-            data: new URL('https://example.com/image1.jpg'),
+            data: {
+              type: 'url',
+              url: new URL('https://example.com/image1.jpg'),
+            },
             mediaType: 'image/jpeg',
           },
           {
             type: 'file',
-            data: 'data:image/png;base64,iVBOR...',
+            data: { type: 'data', data: 'data:image/png;base64,iVBOR...' },
             mediaType: 'image/png',
           },
           {
             type: 'file',
-            data: new Uint8Array([255, 216, 255, 224]),
+            data: { type: 'data', data: new Uint8Array([255, 216, 255, 224]) },
             mediaType: 'image/jpeg',
           },
         ],
@@ -900,7 +922,7 @@ describe('convertToOllamaChatMessages', () => {
         content: [
           {
             type: 'file',
-            data: new URL('https://example.com/image.jpg'),
+            data: { type: 'url', url: new URL('https://example.com/image.jpg') },
             mediaType: 'image/jpeg',
           },
         ],

--- a/packages/ai-sdk-ollama/src/utils/convert-to-ollama-messages.ts
+++ b/packages/ai-sdk-ollama/src/utils/convert-to-ollama-messages.ts
@@ -1,11 +1,33 @@
-import { LanguageModelV3Prompt } from '@ai-sdk/provider';
+import { LanguageModelV4Prompt, SharedV4FileData } from '@ai-sdk/provider';
 import { Message as OllamaMessage } from 'ollama';
 
 import { parseToolArguments } from './tool-calling-reliability';
 
 function normalizeImageDataForOllama(
-  imageData: URL | string | Uint8Array,
+  fileData: SharedV4FileData | URL | string | Uint8Array,
 ): string | null {
+  // AI SDK v7 (LanguageModelV4) delivers file data as a tagged discriminated
+  // union. Unwrap it to the underlying URL / string / bytes before normalizing.
+  let imageData: URL | string | Uint8Array;
+  if (
+    fileData !== null &&
+    typeof fileData === 'object' &&
+    !(fileData instanceof URL) &&
+    !(fileData instanceof Uint8Array) &&
+    'type' in fileData
+  ) {
+    if (fileData.type === 'data') {
+      imageData = fileData.data;
+    } else if (fileData.type === 'url') {
+      imageData = fileData.url;
+    } else {
+      // `reference` (provider file id) and `text` are not inline image data.
+      return null;
+    }
+  } else {
+    imageData = fileData;
+  }
+
   if (imageData instanceof URL) {
     if (imageData.protocol === 'data:') {
       const base64Match = imageData.href.match(/data:[^;]+;base64,(.+)/);
@@ -34,7 +56,7 @@ function normalizeImageDataForOllama(
  * and handles edge cases better than the referenced implementation
  */
 export function convertToOllamaChatMessages(
-  prompt: LanguageModelV3Prompt,
+  prompt: LanguageModelV4Prompt,
 ): OllamaMessage[] {
   const messages: OllamaMessage[] = [];
 
@@ -152,17 +174,11 @@ export function convertToOllamaChatMessages(
                     textParts.push(item.text);
                     break;
                   }
-                  case 'image-data': {
-                    const normalized = normalizeImageDataForOllama(item.data);
-                    if (normalized) imageParts.push(normalized);
-                    break;
-                  }
-                  case 'image-url': {
-                    imageParts.push(item.url);
-                    break;
-                  }
-                  case 'file-data': {
-                    if (item.mediaType?.startsWith('image/')) {
+                  // AI SDK v7 consolidated the former `image-data` / `image-url`
+                  // / `file-data` tool-result outputs into a single `file` part
+                  // carrying a tagged `SharedV4FileData` payload.
+                  case 'file': {
+                    if (item.mediaType?.startsWith('image')) {
                       const normalized = normalizeImageDataForOllama(item.data);
                       if (normalized) imageParts.push(normalized);
                     }

--- a/packages/ai-sdk-ollama/src/utils/map-ollama-finish-reason.ts
+++ b/packages/ai-sdk-ollama/src/utils/map-ollama-finish-reason.ts
@@ -1,7 +1,7 @@
-import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
+import { LanguageModelV4FinishReason } from '@ai-sdk/provider';
 
 /**
- * Maps Ollama finish reasons to the AI SDK V3 LanguageModelV3FinishReason format.
+ * Maps Ollama finish reasons to the AI SDK V3 LanguageModelV4FinishReason format.
  *
  * In V3, FinishReason is an object with:
  * - unified: standardized reason ('stop', 'length', 'content-filter', 'tool-calls', 'error', 'other')
@@ -10,7 +10,7 @@ import { LanguageModelV3FinishReason } from '@ai-sdk/provider';
 export function mapOllamaFinishReason(
   reason?: string | null,
   hasToolCalls = false,
-): LanguageModelV3FinishReason {
+): LanguageModelV4FinishReason {
   if (hasToolCalls) {
     return {
       unified: 'tool-calls',

--- a/packages/ai-sdk-ollama/src/utils/tool-calling-reliability.ts
+++ b/packages/ai-sdk-ollama/src/utils/tool-calling-reliability.ts
@@ -10,11 +10,11 @@
  */
 
 import {
-  LanguageModelV3CallOptions,
-  LanguageModelV3Content,
-  LanguageModelV3FunctionTool,
-  LanguageModelV3Prompt,
-  LanguageModelV3ToolResultPart,
+  LanguageModelV4CallOptions,
+  LanguageModelV4Content,
+  LanguageModelV4FunctionTool,
+  LanguageModelV4Prompt,
+  LanguageModelV4ToolResultPart,
 } from '@ai-sdk/provider';
 import { jsonrepair } from 'jsonrepair';
 
@@ -159,7 +159,7 @@ export function parseToolArguments(input?: unknown): Record<string, unknown> {
 }
 
 export function createToolDefinitionMap(
-  tools?: Array<LanguageModelV3FunctionTool>,
+  tools?: Array<LanguageModelV4FunctionTool>,
 ): Record<string, ToolDefinition> {
   if (!tools || tools.length === 0) {
     return {};
@@ -169,7 +169,7 @@ export function createToolDefinitionMap(
   for (const tool of tools) {
     // Skip tools that don't have an execute function
     if (
-      typeof (tool as LanguageModelV3FunctionTool & { execute?: unknown })
+      typeof (tool as LanguageModelV4FunctionTool & { execute?: unknown })
         .execute !== 'function'
     ) {
       continue;
@@ -181,7 +181,7 @@ export function createToolDefinitionMap(
           ? (tool.inputSchema as Record<string, unknown>)
           : { type: 'object', properties: {} },
       execute: (
-        tool as LanguageModelV3FunctionTool & {
+        tool as LanguageModelV4FunctionTool & {
           execute: (params: Record<string, unknown>) => Promise<unknown>;
         }
       ).execute,
@@ -191,7 +191,7 @@ export function createToolDefinitionMap(
 }
 
 export function extractToolCallsFromContent(
-  content: LanguageModelV3Content[],
+  content: LanguageModelV4Content[],
 ): Array<{ toolName: string; input: Record<string, unknown> }> {
   return content
     .filter(
@@ -205,7 +205,7 @@ export function extractToolCallsFromContent(
 }
 
 export function extractToolResultsFromPrompt(
-  prompt: LanguageModelV3Prompt | undefined,
+  prompt: LanguageModelV4Prompt | undefined,
 ): Array<{ toolName: string; result: unknown; toolCallId?: string }> {
   if (!prompt || !Array.isArray(prompt)) {
     return [];
@@ -222,7 +222,7 @@ export function extractToolResultsFromPrompt(
       continue;
     }
 
-    for (const part of message.content as Array<LanguageModelV3ToolResultPart>) {
+    for (const part of message.content as Array<LanguageModelV4ToolResultPart>) {
       if (part.type !== 'tool-result') {
         continue;
       }
@@ -246,17 +246,26 @@ export function extractToolResultsFromPrompt(
             if (item.type === 'text') {
               return { type: 'text', text: item.text };
             }
-            if (item.type === 'file-data') {
+            // AI SDK v7 consolidated `file-data` / `file-url` tool-result
+            // outputs into a single `file` part with a tagged `SharedV4FileData`
+            // payload.
+            if (item.type === 'file') {
+              if (item.data.type === 'url') {
+                return {
+                  type: 'media',
+                  url: String(item.data.url),
+                };
+              }
+              if (item.data.type === 'data') {
+                return {
+                  type: 'media',
+                  mediaType: item.mediaType,
+                  data: item.data.data,
+                };
+              }
               return {
                 type: 'media',
                 mediaType: item.mediaType,
-                data: item.data,
-              };
-            }
-            if (item.type === 'file-url') {
-              return {
-                type: 'media',
-                url: item.url,
               };
             }
             return item;
@@ -614,12 +623,12 @@ export async function executeReliableToolCalls(
 export async function forceCompletion(
   model: {
     doGenerate: (
-      options: LanguageModelV3CallOptions,
-    ) => Promise<{ content: LanguageModelV3Content[] }>;
+      options: LanguageModelV4CallOptions,
+    ) => Promise<{ content: LanguageModelV4Content[] }>;
   },
   originalPrompt: string,
   toolResults: Array<{ toolName: string; result: unknown }>,
-  options: Omit<LanguageModelV3CallOptions, 'prompt'> = {},
+  options: Omit<LanguageModelV4CallOptions, 'prompt'> = {},
 ): Promise<string> {
   const expectsJson = options.responseFormat?.type === 'json';
   const finalInstruction = expectsJson
@@ -654,12 +663,12 @@ ${finalInstruction}`;
  */
 export async function reliableToolCall(
   model: {
-    doGenerate: (options: LanguageModelV3CallOptions) => Promise<{
-      content: LanguageModelV3Content[];
+    doGenerate: (options: LanguageModelV4CallOptions) => Promise<{
+      content: LanguageModelV4Content[];
       toolCalls?: Array<{ toolName: string; input: Record<string, unknown> }>;
     }>;
   },
-  options: LanguageModelV3CallOptions & {
+  options: LanguageModelV4CallOptions & {
     tools?: Record<string, ToolDefinition>;
   },
   reliabilityOptions: ToolCallingOptions = {},
@@ -773,15 +782,15 @@ export async function reliableToolCall(
  */
 export function createReliableToolCallWrapper(
   model: {
-    doGenerate: (options: LanguageModelV3CallOptions) => Promise<{
-      content: LanguageModelV3Content[];
+    doGenerate: (options: LanguageModelV4CallOptions) => Promise<{
+      content: LanguageModelV4Content[];
       toolCalls?: Array<{ toolName: string; input: Record<string, unknown> }>;
     }>;
   },
   reliabilityOptions: ToolCallingOptions = {},
 ) {
   return async (
-    options: LanguageModelV3CallOptions & {
+    options: LanguageModelV4CallOptions & {
       tools?: Record<string, ToolDefinition>;
     },
   ) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
   examples/browser:
     dependencies:
       '@ai-sdk/react':
-        specifier: ^3.0.208
-        version: 3.0.208(react@19.2.7)(zod@4.4.3)
+        specifier: 4.0.0-beta.183
+        version: 4.0.0-beta.183(react@19.2.7)(zod@4.4.3)
       '@radix-ui/react-avatar':
         specifier: ^1.2.0
         version: 1.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -89,8 +89,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
       ai:
-        specifier: ^6.0.207
-        version: 6.0.207(zod@4.4.3)
+        specifier: 7.0.0-beta.179
+        version: 7.0.0-beta.179(zod@4.4.3)
       ai-sdk-ollama:
         specifier: workspace:*
         version: link:../../packages/ai-sdk-ollama
@@ -165,11 +165,11 @@ importers:
   examples/node:
     dependencies:
       '@ai-sdk/mcp':
-        specifier: ^1.0.52
-        version: 1.0.52(zod@4.4.3)
+        specifier: 2.0.0-beta.66
+        version: 2.0.0-beta.66(zod@4.4.3)
       ai:
-        specifier: ^6.0.207
-        version: 6.0.207(zod@4.4.3)
+        specifier: 7.0.0-beta.179
+        version: 7.0.0-beta.179(zod@4.4.3)
       ai-sdk-ollama:
         specifier: workspace:*
         version: link:../../packages/ai-sdk-ollama
@@ -199,14 +199,14 @@ importers:
   packages/ai-sdk-ollama:
     dependencies:
       '@ai-sdk/provider':
-        specifier: ^3.0.10
-        version: 3.0.10
+        specifier: 4.0.0-beta.19
+        version: 4.0.0-beta.19
       '@ai-sdk/provider-utils':
-        specifier: ^4.0.30
-        version: 4.0.30(zod@4.4.3)
+        specifier: 5.0.0-beta.49
+        version: 5.0.0-beta.49(zod@4.4.3)
       ai:
-        specifier: ^6.0.197
-        version: 6.0.197(zod@4.4.3)
+        specifier: '>=7.0.0-beta.179 <8.0.0'
+        version: 7.0.0-beta.179(zod@4.4.3)
       jsonrepair:
         specifier: ^3.14.0
         version: 3.14.0
@@ -271,55 +271,31 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@3.0.125':
-    resolution: {integrity: sha512-tocl7cUDoTpmhZqeW8XVKMMznZQwwQAEunF0VyNKmf64qt8NbMIAEiet/vRMzh7Jr9WcFeb6EZjmhLTP4Qx2Og==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.0-beta.110':
+    resolution: {integrity: sha512-Q1u+cERhomoTLxGxdywRFcqGWMctmWzFpVhi2irag/9vMa/DwyDB2qvww8zg9CE23qol0Yw5pNaExOACPsQlBQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.132':
-    resolution: {integrity: sha512-sFZFGk6aVSNKmgDrb14efaAbvM71AB3UUvaTsU+bvhWP9jrkRrwix/jFX8IoOAJk0/X7Xf7p3m0J2O2G6ljZbA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/mcp@2.0.0-beta.66':
+    resolution: {integrity: sha512-Jodv9W0aHKRWBLfyGZ3pcc3bXLoEldgEqC4k+E1ozaL5XjYuZfqnjfsGpx6BkX3GCr3mVctPwRGG09QCYP5lJA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.133':
-    resolution: {integrity: sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.0-beta.49':
+    resolution: {integrity: sha512-7xnpAQLpW0KGIsh0CQERcIZuXEGqv7FtFW2BdFk14iuMxRMVpXhTVvEQyqkm6tWAbQ7OsGQJhO6M0Me9gHQ52g==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/mcp@1.0.52':
-    resolution: {integrity: sha512-yudE3Mdl8fsbzjMepOPbikA6nIRWOez+5e/IvOv1jK6XMAtsZ4+Xz8vjRQHI77VMv2TdiaMfsKKFoW6dlZRT3g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
+  '@ai-sdk/provider@4.0.0-beta.19':
+    resolution: {integrity: sha512-Aca/KiGeRtMM7rOJ38Qio+Dc2V45PpiGoWgdrdtIkgM9zkhYpS043t0ggKoNOWgm/csv99XWGrfSF63PSkVeHw==}
+    engines: {node: '>=22'}
 
-  '@ai-sdk/provider-utils@4.0.27':
-    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.29':
-    resolution: {integrity: sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.30':
-    resolution: {integrity: sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@3.0.10':
-    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/react@3.0.208':
-    resolution: {integrity: sha512-HEhPWLlg5wPqnadGqDRBek8V3GzmlLH3v4PCvDY/GCsDTNKk2nYpExvl8mXu20gVT4h+79OCAy9ozKrdTXi+4A==}
-    engines: {node: '>=18'}
+  '@ai-sdk/react@4.0.0-beta.183':
+    resolution: {integrity: sha512-7Czxzr1sYCLa64ua/x2/qnBiqN7EKW+hHOp64H8OwF3yXvqgHS442yURuxn4zb8zqRzaaPQFgPU/C/mQy1tnsg==}
+    engines: {node: '>=22'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
@@ -1963,6 +1939,9 @@ packages:
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1978,21 +1957,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ai@6.0.197:
-    resolution: {integrity: sha512-U3KsjkqwQXGHC0u0VeUDqUaNaBS/uQc7v4Vj92Cjv5lPx5DIyRBQYk4Hipy5vwD9AQKIG8uRvdaN9R+pAvrtcQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  ai@6.0.206:
-    resolution: {integrity: sha512-hVdB5PozMMxmkPBfbCxkFOn0eVeCMi/imkfPvk65cxL4O8oIrvjUxDUX8dGkdkWG1No+R7e7D9ti2DHO61Z4YQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  ai@6.0.207:
-    resolution: {integrity: sha512-9rAHnqU+AvxyqO6WgiWj7hQENX6AprHXZWZEdBWwgnA854D2Mje/PiTmbcFqO+2Cck1lII0NLRQJY9lmdSorMw==}
-    engines: {node: '>=18'}
+  ai@7.0.0-beta.179:
+    resolution: {integrity: sha512-1TUNZXcPDuliUH5IMW17AZmZr/PPuIu4p2+iRpXwM+Pl5i2qcfoEItMElo5bzVQNFmBl5CxY9g5sSt/fEcZSuQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -4056,63 +4023,38 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.125(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.0-beta.110(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0-beta.19
+      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.132(zod@4.4.3)':
+  '@ai-sdk/mcp@2.0.0-beta.66(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
-      '@vercel/oidc': 3.2.0
-      zod: 4.4.3
-
-  '@ai-sdk/gateway@3.0.133(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
-      '@vercel/oidc': 3.2.0
-      zod: 4.4.3
-
-  '@ai-sdk/mcp@1.0.52(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0-beta.19
+      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.4.3)
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.0-beta.49(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider': 4.0.0-beta.19
       '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.29(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-
-  '@ai-sdk/provider-utils@4.0.30(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-
-  '@ai-sdk/provider@3.0.10':
+  '@ai-sdk/provider@4.0.0-beta.19':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.208(react@19.2.7)(zod@4.4.3)':
+  '@ai-sdk/react@4.0.0-beta.183(react@19.2.7)(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
-      ai: 6.0.206(zod@4.4.3)
+      '@ai-sdk/mcp': 2.0.0-beta.66(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0-beta.19
+      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.4.3)
+      ai: 7.0.0-beta.179(zod@4.4.3)
       react: 19.2.7
       swr: 2.4.1(react@19.2.7)
       throttleit: 2.1.0
@@ -4679,7 +4621,8 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opentelemetry/api@1.9.1': {}
+  '@opentelemetry/api@1.9.1':
+    optional: true
 
   '@oxc-project/types@0.133.0': {}
 
@@ -5639,6 +5582,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@workflow/serde@4.1.0': {}
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -5647,28 +5592,11 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  ai@6.0.197(zod@4.4.3):
+  ai@7.0.0-beta.179(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.125(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
-      zod: 4.4.3
-
-  ai@6.0.206(zod@4.4.3):
-    dependencies:
-      '@ai-sdk/gateway': 3.0.132(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
-      zod: 4.4.3
-
-  ai@6.0.207(zod@4.4.3):
-    dependencies:
-      '@ai-sdk/gateway': 3.0.133(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.0-beta.110(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0-beta.19
+      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.4.3)
       zod: 4.4.3
 
   ajv@6.15.0:


### PR DESCRIPTION
Migrates the provider from AI SDK v6 to v7 (beta). Major, breaking release published as `4.0.0-beta.0` under the `beta` dist-tag (the `latest` tag stays on `3.8.x` for AI SDK v6 users).

## Changes
- Bump peers/deps to `ai@7`, `@ai-sdk/provider@4`, `@ai-sdk/provider-utils@5`
- Migrate all models (chat, embedding, image, reranking) to the **V4 provider spec** (`specificationVersion: 'v4'`)
- Read the new `SharedV4FileData` tagged file-data union and the consolidated `file` tool-result output. **Fixes multimodal image inputs under v7** (the SDK now sends `{type:'data'|'url'}`, which the old converter mishandled)
- Update `tool()` helper usages (web search/fetch) for the v7 `Tool<INPUT, OUTPUT, CONTEXT>` signature and required `ToolExecutionOptions.context`
- **Per-call reasoning effort**: map `LanguageModelV4CallOptions.reasoning` onto Ollama's `think` parameter (`resolveThink`), assembled via a single `buildChatRequest` helper that de-duplicates the request envelope across all 5 `client.chat()` sites
- New node examples: `ToolLoopAgent` + `isStepCount`, tool approval (HITL), `rerank`, per-call reasoning effort
- Document v3/v6 vs v4/v7 coexistence in both READMEs

## Breaking
- Requires `ai@^7`.
- The re-exported agent callback types `ToolLoopAgentOnFinishCallback` / `ToolLoopAgentOnStepFinishCallback` were renamed upstream to `GenerateTextOnFinishCallback` / `GenerateTextOnStepFinishCallback`.

## Verification
- type-check (0 errors), 242 unit tests, lint, build, check-exports, both example projects: all green
- Verified live against local Ollama: generate, stream, embeddings, structured output, tool calling, reliable tool/object paths, reranking, and reasoning effort (`reasoning: 'none'` disables thinking, `'high'` enables it) on both `generateText` and `streamText`

## Release mechanics
This branch enters changesets **beta pre-mode** (`.changeset/pre.json`). On merge to `main`, the release workflow opens a "Version Packages" PR for `4.0.0-beta.0`; merging that publishes to npm under the `beta` tag via OIDC. `latest` is unaffected.