### PR TITLE
feat!: upgrade to AI SDK v7 GA

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@examples/browser": "1.0.0",

--- a/README.md
+++ b/README.md
@@ -5,27 +5,27 @@
 [![Node.js](https://img.shields.io/badge/Node.js-22+-green.svg)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A Vercel AI SDK provider for Ollama built on the official `ollama` package. Type safe, future proof, with cross provider compatibility and native Ollama features.
+A Vercel AI SDK provider for Ollama, built on the official `ollama` package. Type-safe, cross-provider compatible, with access to native Ollama features.
 
-> **📌 Version compatibility**
+> **Version compatibility**
 >
 > Each `ai-sdk-ollama` major targets one AI SDK major. Every line stays published on npm, so pick the one that matches your `ai` version:
 >
 > | `ai-sdk-ollama` | `ai` (peer) | Status |
 > | --- | --- | --- |
-> | `4.x` (`@beta`) | `ai@^7` (beta) | Active. New features land here. |
+> | `4.x` (`@latest`) | `ai@^7` | Active. New features land here. |
 > | `3.x` | `ai@^6` | Maintenance. Critical fixes only. |
 > | `2.x` | `ai@^5` | Unmaintained. |
 >
-> While AI SDK v7 is in beta, install v4 from the `beta` tag. The v3 line keeps working for AI SDK v6 the whole time. Once AI SDK v7 ships stable, v4 moves to the `latest` tag.
+> AI SDK v7 is stable, so v4 installs from `latest`. The v3 line still works for AI SDK v6.
 
 ## Quick Start
 
 ```bash
-# AI SDK v7 (beta)
-npm install ai-sdk-ollama@beta ai@beta
+# AI SDK v7 (stable)
+npm install ai-sdk-ollama ai
 
-# AI SDK v6 (stable)
+# AI SDK v6
 npm install ai-sdk-ollama@^3 ai@^6
 ```
 
@@ -53,15 +53,15 @@ console.log(text);
 - **Reranking** - Document relevance ranking using embedding-based similarity
 - **Middleware system** - Wrap models with `defaultSettingsMiddleware` and `extractReasoningMiddleware`
 - **ToolLoopAgent** - Autonomous agents that run tool loops with configurable stop conditions
-- **Streaming utilities** - `smoothStream`, `createStitchableStream`, `parsePartialJson` for stream manipulation
+- **Streaming utilities** - `smoothStream` and `parsePartialJson` for stream handling
 - **Type-safe** - Full TypeScript support with strict typing
-- **Cross-environment** - Works in Node.js and browsers automatically
-- **Native Ollama features** - Access to advanced options like `mirostat`, `repeat_penalty`, `num_ctx`
-- **Production ready** - Addresses common Ollama integration challenges
+- **Cross-environment** - Runs in Node.js and browsers automatically
+- **Native Ollama features** - Use advanced options like `mirostat`, `repeat_penalty`, `num_ctx`
+- **Production-ready** - Handles the tool-call and JSON edge cases that otherwise need manual workarounds
 
 ## Enhanced Tool Calling
 
-> **Tool Calling Enhancement**: Standard Ollama providers may execute tools but return incomplete responses. Our enhanced functions provide more reliable response synthesis.
+> **The problem this solves**: Standard Ollama providers can execute a tool and then return empty text. These wrapper functions synthesize a response so you get complete output.
 
 ```typescript
 import { generateText, streamText } from 'ai-sdk-ollama';
@@ -87,7 +87,7 @@ const { textStream } = await streamText({
 
 ### Combining Tools with Structured Output
 
-> **Advanced Feature**: The `enableToolsWithStructuredOutput` option allows you to use both tool calling and structured output together, which is typically not possible with standard AI SDK implementations.
+> **Tools + structured output**: The `enableToolsWithStructuredOutput` option lets you use tool calling and structured output in the same call.
 
 ```typescript
 import { generateText } from 'ai-sdk-ollama';
@@ -107,7 +107,7 @@ const weatherTool = tool({
   }),
 });
 
-// AI SDK v6: tools and structured output work together by default
+// AI SDK v7: tools and structured output work together by default
 const result = await generateText({
   model: ollama('llama3.2'),
   prompt: 'Get weather for San Francisco and provide a structured summary',
@@ -126,7 +126,7 @@ const result = await generateText({
 
 ## Web Search Tools
 
-> **Web Search Integration**: Built-in web search and fetch tools powered by [Ollama's web search API](https://ollama.com/blog/web-search). Useful for accessing current information.
+> **Web search and fetch**: Built-in tools powered by [Ollama's web search API](https://ollama.com/blog/web-search) for current information.
 
 ```typescript
 import { generateText } from 'ai';
@@ -309,13 +309,13 @@ const { output } = await generateText({
   prompt: 'Generate a random person profile',
 });
 
-console.log(object);
+console.log(output);
 // { name: "Alice", age: 28, interests: ["reading", "hiking"] }
 ```
 
 ### MCP (Model Context Protocol) Integration
 
-> **AI SDK v6 Feature**: Full MCP support including OAuth authentication, resources, prompts, and elicitation.
+> **MCP support**: OAuth authentication, resources, prompts, and elicitation.
 
 ```typescript
 import { generateText } from 'ai';
@@ -398,7 +398,7 @@ const results = await Promise.all(
 
 ### Reranking
 
-> **AI SDK v6 Feature**: Native reranking support for improving search results and RAG pipelines.
+> **Reranking**: Rank documents to improve search results and RAG pipelines.
 
 ```typescript
 import { rerank } from 'ai';
@@ -469,16 +469,16 @@ import { z } from 'zod';
 
 const agent = new ToolLoopAgent({
   model: ollama('llama3.2'),
-  system: 'You are a helpful assistant.',
+  instructions: 'You are a helpful assistant.',
   tools: {
     weather: tool({
       description: 'Get weather for a location',
-      parameters: z.object({ location: z.string() }),
+      inputSchema: z.object({ location: z.string() }),
       execute: async ({ location }) => ({ temp: 72, condition: 'sunny' }),
     }),
     done: tool({
       description: 'Signal task completion',
-      parameters: z.object({ summary: z.string() }),
+      inputSchema: z.object({ summary: z.string() }),
       execute: async ({ summary }) => ({ completed: true, summary }),
     }),
   },
@@ -524,7 +524,7 @@ const result = streamText({
 
 - [Ollama](https://ollama.com) installed and running locally
 - Node.js 22+ for development
-- AI SDK v6 (`ai` package)
+- AI SDK v7 (`ai` package)
 
 ```bash
 # Start Ollama

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -16,7 +16,7 @@
     "quality": "pnpm type-check && pnpm build"
   },
   "dependencies": {
-    "@ai-sdk/react": "4.0.0-canary.180",
+    "@ai-sdk/react": "^4.0.0",
     "@radix-ui/react-avatar": "^1.2.0",
     "@radix-ui/react-collapsible": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.18",
@@ -28,7 +28,7 @@
     "@radix-ui/react-tooltip": "^1.2.10",
     "@radix-ui/react-use-controllable-state": "^1.2.3",
     "@tailwindcss/vite": "^4.3.1",
-    "ai": "7.0.0-canary.176",
+    "ai": "^7.0.0",
     "ai-sdk-ollama": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -8,8 +8,8 @@
     "quality": "pnpm build"
   },
   "dependencies": {
-    "@ai-sdk/mcp": "2.0.0-canary.65",
-    "ai": "7.0.0-canary.176",
+    "@ai-sdk/mcp": "^2.0.0",
+    "ai": "^7.0.0",
     "ai-sdk-ollama": "workspace:*",
     "dotenv": "^17.4.2",
     "ollama": "^0.6.3",

--- a/packages/ai-sdk-ollama/README.md
+++ b/packages/ai-sdk-ollama/README.md
@@ -5,27 +5,27 @@
 [![Node.js](https://img.shields.io/badge/Node.js-22+-green.svg)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A Vercel AI SDK provider for Ollama built on the official `ollama` package. Type safe, future proof, with cross provider compatibility and native Ollama features.
+A Vercel AI SDK provider for Ollama, built on the official `ollama` package. Type-safe, cross-provider compatible, with access to native Ollama features.
 
-> **📌 Version compatibility**
+> **Version compatibility**
 >
 > Each `ai-sdk-ollama` major targets one AI SDK major. Every line stays published on npm, so pick the one that matches your `ai` version:
 >
 > | `ai-sdk-ollama` | `ai` (peer) | Status |
 > | --- | --- | --- |
-> | `4.x` (`@beta`) | `ai@^7` (beta) | Active. New features land here. |
+> | `4.x` (`@latest`) | `ai@^7` | Active. New features land here. |
 > | `3.x` | `ai@^6` | Maintenance. Critical fixes only. |
 > | `2.x` | `ai@^5` | Unmaintained. |
 >
-> While AI SDK v7 is in beta, install v4 from the `beta` tag. The v3 line keeps working for AI SDK v6 the whole time. Once AI SDK v7 ships stable, v4 moves to the `latest` tag.
+> AI SDK v7 is stable, so v4 installs from `latest`. The v3 line still works for AI SDK v6.
 
 ## Quick Start
 
 ```bash
-# AI SDK v7 (beta)
-npm install ai-sdk-ollama@beta ai@beta
+# AI SDK v7 (stable)
+npm install ai-sdk-ollama ai
 
-# AI SDK v6 (stable)
+# AI SDK v6
 npm install ai-sdk-ollama@^3 ai@^6
 ```
 
@@ -45,24 +45,24 @@ console.log(text);
 
 ## Why Choose AI SDK Ollama?
 
-- ✅ **Solves tool calling problems** - Response synthesis for reliable tool execution
-- ✅ **Enhanced wrapper functions** - `generateText` and `streamText` guarantees complete responses
-- ✅ **Built-in reliability** - Default reliability features enabled automatically
-- ✅ **Automatic JSON repair** - Cascade repair: [jsonrepair](https://github.com/josdejong/jsonrepair) first, then Ollama-specific fallback (trailing commas, comments, URLs, Python constants, etc.)
-- ✅ **Web search and fetch tools** - Built-in web search and fetch tools powered by [Ollama's web search API](https://ollama.com/blog/web-search). Perfect for getting current information and reducing hallucinations.
-- ✅ **Type-safe** - Full TypeScript support with strict typing
-- ✅ **Cross-environment** - Works in Node.js and browsers automatically
-- ✅ **Native Ollama power** - Access advanced features like `mirostat`, `repeat_penalty`, `num_ctx`
-- ✅ **Production ready** - Handles the core Ollama limitations other providers struggle with
+- **Reliable tool calling** - Response synthesis adds text after tool execution, so you don't get empty replies
+- **Wrapper functions** - `generateText` and `streamText` return complete responses
+- **Built-in reliability** - Reliability features run by default
+- **Automatic JSON repair** - Cascade repair runs [jsonrepair](https://github.com/josdejong/jsonrepair) first, then an Ollama-specific fallback for trailing commas, comments, URLs, and Python constants
+- **Web search and fetch** - Built-in tools powered by [Ollama's web search API](https://ollama.com/blog/web-search) for current information
+- **Type-safe** - Full TypeScript support with strict typing
+- **Cross-environment** - Runs in Node.js and browsers automatically
+- **Native Ollama options** - Use `mirostat`, `repeat_penalty`, `num_ctx`, and more
+- **Production-ready** - Handles the tool-call and JSON edge cases that otherwise need manual workarounds
 
 ## Enhanced Tool Calling
 
-> **🚀 The Problem We Solve**: Standard Ollama providers often execute tools but return empty responses. Our enhanced functions guarantee complete, useful responses every time.
+> **The problem this solves**: Standard Ollama providers can execute a tool and then return empty text. These wrapper functions synthesize a response so you get complete output.
 
 ```typescript
 import { ollama, generateText, streamText } from 'ai-sdk-ollama';
 
-// ✅ Enhanced generateText - guaranteed complete responses
+// Enhanced generateText - returns complete responses after tool calls
 const { text } = await generateText({
   model: ollama('llama3.2'),
   tools: {
@@ -71,7 +71,7 @@ const { text } = await generateText({
   prompt: 'Use the tools and explain the results',
 });
 
-// ✅ Enhanced streaming - tool-aware streaming
+// Enhanced streaming - tool-aware streaming
 const { textStream } = await streamText({
   model: ollama('llama3.2'),
   tools: {
@@ -83,7 +83,7 @@ const { textStream } = await streamText({
 
 ## Web Search Tools
 
-> **🌐 New in v0.9.0**: Built-in web search and fetch tools powered by [Ollama's web search API](https://ollama.com/blog/web-search). Perfect for getting current information and reducing hallucinations.
+> **Web search and fetch**: Built-in tools powered by [Ollama's web search API](https://ollama.com/blog/web-search) for current information.
 
 ```typescript
 import { generateText } from 'ai';
@@ -205,7 +205,7 @@ const { text: advancedText } = await generateText({
 
 - Node.js 22+
 - [Ollama](https://ollama.com) installed locally or running on a remote server
-- AI SDK v6 (`ai` package)
+- AI SDK v7 (`ai` package)
 - TypeScript 5.9+ (for TypeScript users)
 
 ```bash
@@ -333,7 +333,7 @@ const { text } = await generateText({
 
 ### Enhanced Tool Calling Wrappers
 
-For maximum tool calling reliability, use our enhanced wrapper functions that guarantee complete responses:
+For reliable tool calling, use the enhanced wrapper functions that return complete responses:
 
 ```typescript
 import { ollama, generateText, streamText } from 'ai-sdk-ollama';
@@ -388,9 +388,7 @@ const weatherTool = tool({
   }),
 });
 
-// AI SDK v6: tools and structured output work together by default
-import { ollama } from 'ai-sdk-ollama';
-
+// AI SDK v7: tools and structured output work together by default
 const result = await generateText({
   model: ollama('llama3.2'),
   prompt: 'Get weather for San Francisco and provide a structured summary',
@@ -409,7 +407,7 @@ const result = await generateText({
 
 **When to Use Enhanced Wrappers:**
 
-- **Critical tool calling scenarios** where you need guaranteed text responses
+- **Critical tool calling scenarios** where you need a text response after the tool runs
 - **Production applications** that can't handle empty responses after tool execution
 - **Complex multi-step tool interactions** requiring reliable synthesis
 
@@ -418,7 +416,7 @@ const result = await generateText({
 | Function                   | Standard `generateText`   | Enhanced `generateText`              |
 | -------------------------- | ------------------------- | ------------------------------------ |
 | **Simple prompts**         | ✅ Perfect                | ✅ Works (slight overhead)           |
-| **Tool calling**           | ⚠️ May return empty text  | ✅ **Guarantees complete responses** |
+| **Tool calling**           | ⚠️ May return empty text  | ✅ **Returns complete responses**    |
 | **Complete responses**     | ❌ Manual handling needed | ✅ **Automatic completion**          |
 | **Production reliability** | ⚠️ Unpredictable          | ✅ **Reliable**                      |
 
@@ -444,7 +442,7 @@ const { text } = await generateText({
 
 ## Reranking
 
-> **AI SDK v6 Feature**: Rerank documents by semantic relevance to improve search results and RAG pipelines.
+> **Reranking**: Rank documents by semantic relevance for search results and RAG pipelines.
 
 Since Ollama doesn't have native reranking yet, we provide embedding-based reranking using cosine similarity:
 
@@ -832,7 +830,7 @@ const { text } = await generateText({
 
 ### Automatic JSON Repair
 
-> **🔧 Enhanced Reliability**: Built-in cascade repair automatically fixes malformed LLM outputs for object generation.
+> **Cascade JSON repair**: Built-in repair fixes malformed model output during object generation.
 
 Repair uses a **cascade**: the [jsonrepair](https://github.com/josdejong/jsonrepair) library runs first (standard JSON issues), then the built-in Ollama-specific repair runs if needed (e.g. Python `True`/`None`, URLs with `//`, smart quotes). You can use the default, disable repair with `enableTextRepair: false`, or pass a custom `repairText` function. Exported helpers: `cascadeRepairText`, `enhancedRepairText` (see [test-cascade-repair example](../../examples/node/src/test-cascade-repair.ts)).
 
@@ -970,7 +968,7 @@ Install with: `ollama pull deepseek-r1:7b`
 - **Model compatibility errors** - The provider will throw errors if you try to use unsupported features (e.g., tools with non-compatible models)
 - **Network issues** - Verify Ollama is accessible at the configured URL
 - **TypeScript support** - Full type safety with TypeScript 5.9+
-- **AI SDK v6 compatibility** - Built for the latest AI SDK specification
+- **AI SDK v7 compatibility** - Built for the AI SDK v7 specification
 
 ## Supported Models
 

--- a/packages/ai-sdk-ollama/package.json
+++ b/packages/ai-sdk-ollama/package.json
@@ -84,13 +84,13 @@
     "tool-calling"
   ],
   "dependencies": {
-    "@ai-sdk/provider": "4.0.0-canary.18",
-    "@ai-sdk/provider-utils": "5.0.0-canary.48",
+    "@ai-sdk/provider": "^4.0.0",
+    "@ai-sdk/provider-utils": "^5.0.0",
     "jsonrepair": "^3.14.0",
     "ollama": "^0.6.3"
   },
   "peerDependencies": {
-    "ai": ">=7.0.0-beta.179 <8.0.0"
+    "ai": "^7.0.0"
   },
   "devDependencies": {
     "@ai-sdk/test-server": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
   examples/browser:
     dependencies:
       '@ai-sdk/react':
-        specifier: 4.0.0-canary.180
-        version: 4.0.0-canary.180(react@19.2.7)(zod@4.4.3)
+        specifier: ^4.0.0
+        version: 4.0.0(react@19.2.7)(zod@4.4.3)
       '@radix-ui/react-avatar':
         specifier: ^1.2.0
         version: 1.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -89,8 +89,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
       ai:
-        specifier: 7.0.0-canary.176
-        version: 7.0.0-canary.176(zod@4.4.3)
+        specifier: ^7.0.0
+        version: 7.0.0(zod@4.4.3)
       ai-sdk-ollama:
         specifier: workspace:*
         version: link:../../packages/ai-sdk-ollama
@@ -165,11 +165,11 @@ importers:
   examples/node:
     dependencies:
       '@ai-sdk/mcp':
-        specifier: 2.0.0-canary.65
-        version: 2.0.0-canary.65(zod@4.4.3)
+        specifier: ^2.0.0
+        version: 2.0.0(zod@4.4.3)
       ai:
-        specifier: 7.0.0-canary.176
-        version: 7.0.0-canary.176(zod@4.4.3)
+        specifier: ^7.0.0
+        version: 7.0.0(zod@4.4.3)
       ai-sdk-ollama:
         specifier: workspace:*
         version: link:../../packages/ai-sdk-ollama
@@ -199,14 +199,14 @@ importers:
   packages/ai-sdk-ollama:
     dependencies:
       '@ai-sdk/provider':
-        specifier: 4.0.0-canary.18
-        version: 4.0.0-canary.18
+        specifier: ^4.0.0
+        version: 4.0.0
       '@ai-sdk/provider-utils':
-        specifier: 5.0.0-canary.48
-        version: 5.0.0-canary.48(zod@4.4.3)
+        specifier: ^5.0.0
+        version: 5.0.0(zod@4.4.3)
       ai:
-        specifier: '>=7.0.0-beta.179 <8.0.0'
-        version: 7.0.0-beta.179(zod@4.4.3)
+        specifier: ^7.0.0
+        version: 7.0.0(zod@4.4.3)
       jsonrepair:
         specifier: ^3.14.0
         version: 3.14.0
@@ -271,46 +271,30 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@4.0.0-beta.110':
-    resolution: {integrity: sha512-Q1u+cERhomoTLxGxdywRFcqGWMctmWzFpVhi2irag/9vMa/DwyDB2qvww8zg9CE23qol0Yw5pNaExOACPsQlBQ==}
+  '@ai-sdk/gateway@4.0.0':
+    resolution: {integrity: sha512-rcKukspbM4h511ot2E8TsPl7rXjRK1zHKrMCP7w4+XF55UKqQHaDzo2kKbGv5rp8Bjb1yQatIHJZE1E2yrOOMw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@4.0.0-canary.107':
-    resolution: {integrity: sha512-BPmARy2rc0ChkmoMhrmHa+L5lg7HWO8BZ1bMEWx3m3wH6lSy7a2CFu4T28PC2qaCPuWgpu5+PnSWC9eMpZh9rQ==}
+  '@ai-sdk/mcp@2.0.0':
+    resolution: {integrity: sha512-+N6gJ1AbcDk3+6asoEsdIojVmgEReKNcvWIT716pDL3AepGI6j7RJVdaRyhQLltwzTj0arwpwU4BBzvhOiCd/g==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/mcp@2.0.0-canary.65':
-    resolution: {integrity: sha512-giyTeWVykKbgE/VDOlzoq6igW0MbIp60KfFTaxW/NYdmK1sb221Ozb1PaSYEn362tmDv1cnvyBSsXhXahrYzkA==}
+  '@ai-sdk/provider-utils@5.0.0':
+    resolution: {integrity: sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@5.0.0-beta.49':
-    resolution: {integrity: sha512-7xnpAQLpW0KGIsh0CQERcIZuXEGqv7FtFW2BdFk14iuMxRMVpXhTVvEQyqkm6tWAbQ7OsGQJhO6M0Me9gHQ52g==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@5.0.0-canary.48':
-    resolution: {integrity: sha512-340rMqAnqHDZOKS9ayrRbNr0/Om+orcopAnqJ7ftfEskxDUCTcudmhAhctFMSQeMzDnKaBPgz+4iff/hn7PkqQ==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider@4.0.0-beta.19':
-    resolution: {integrity: sha512-Aca/KiGeRtMM7rOJ38Qio+Dc2V45PpiGoWgdrdtIkgM9zkhYpS043t0ggKoNOWgm/csv99XWGrfSF63PSkVeHw==}
+  '@ai-sdk/provider@4.0.0':
+    resolution: {integrity: sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==}
     engines: {node: '>=22'}
 
-  '@ai-sdk/provider@4.0.0-canary.18':
-    resolution: {integrity: sha512-+XBwXEPkN+l/90bb7TaSK15jAq9ScsGrauJ/NLSGip0KX5Mf1pfEfqBWDuJMIYVRYHNdV1dDBy7JCoKUCQe/tA==}
-    engines: {node: '>=22'}
-
-  '@ai-sdk/react@4.0.0-canary.180':
-    resolution: {integrity: sha512-K/HXLEUoDsBH9autqvajtceximk4/w4X4mzmfDdnr2epECedDekZw087MMXaZL3oquiDR0854PRljjzwQUSseQ==}
+  '@ai-sdk/react@4.0.0':
+    resolution: {integrity: sha512-B8QCCzSr/neXnJebBPQpS/rO+I++xhhs81hcaiKD1gU+C7GKg5gZSHLb5iP+AUqrx6VP8QWwgNpHmLlfrlV2rg==}
     engines: {node: '>=22'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
@@ -1363,36 +1347,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -1454,66 +1444,79 @@ packages:
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
@@ -1590,24 +1593,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -1973,14 +1980,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ai@7.0.0-beta.179:
-    resolution: {integrity: sha512-1TUNZXcPDuliUH5IMW17AZmZr/PPuIu4p2+iRpXwM+Pl5i2qcfoEItMElo5bzVQNFmBl5CxY9g5sSt/fEcZSuQ==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  ai@7.0.0-canary.176:
-    resolution: {integrity: sha512-0a+PeTou1uLouzrlLaEZNyBj21oFyYCI1BeOrP9uLJ2YGW6tsUAGME6zetfDdbl/bouIc4neUA36sH7mNjNp1g==}
+  ai@7.0.0:
+    resolution: {integrity: sha512-hncs+jamJh8r36K6G8xky7oF4Ai/RLU5TF85FMzI2vElyMJGGnLoHihpdmuDiuY2BsktDWHevKaJM1l0VcRLGw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2920,24 +2921,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4045,57 +4050,38 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@4.0.0-beta.110(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-beta.19
-      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/gateway@4.0.0-canary.107(zod@4.4.3)':
+  '@ai-sdk/mcp@2.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@4.4.3)
-      '@vercel/oidc': 3.2.0
-      zod: 4.4.3
-
-  '@ai-sdk/mcp@2.0.0-canary.65(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@5.0.0-beta.49(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.0(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-beta.19
+      '@ai-sdk/provider': 4.0.0
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@5.0.0-canary.48(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@standard-schema/spec': 1.1.0
-      '@workflow/serde': 4.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-
-  '@ai-sdk/provider@4.0.0-beta.19':
+  '@ai-sdk/provider@4.0.0':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@4.0.0-canary.18':
+  '@ai-sdk/react@4.0.0(react@19.2.7)(zod@4.4.3)':
     dependencies:
-      json-schema: 0.4.0
-
-  '@ai-sdk/react@4.0.0-canary.180(react@19.2.7)(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/mcp': 2.0.0-canary.65(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@4.4.3)
-      ai: 7.0.0-canary.176(zod@4.4.3)
+      '@ai-sdk/mcp': 2.0.0(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
+      ai: 7.0.0(zod@4.4.3)
       react: 19.2.7
       swr: 2.4.1(react@19.2.7)
       throttleit: 2.1.0
@@ -5633,18 +5619,11 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  ai@7.0.0-beta.179(zod@4.4.3):
+  ai@7.0.0(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 4.0.0-beta.110(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.0-beta.19
-      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.4.3)
-      zod: 4.4.3
-
-  ai@7.0.0-canary.176(zod@4.4.3):
-    dependencies:
-      '@ai-sdk/gateway': 4.0.0-canary.107(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.0-canary.18
-      '@ai-sdk/provider-utils': 5.0.0-canary.48(zod@4.4.3)
+      '@ai-sdk/gateway': 4.0.0(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
 
   ajv@6.15.0:


### PR DESCRIPTION
## Summary

AI SDK 7 is now GA. This moves all pins off beta/canary onto stable carets and finalizes the v7 line for a `4.0.0` release.

- **lib** (`packages/ai-sdk-ollama`): `@ai-sdk/provider` `^4.0.0`, `@ai-sdk/provider-utils` `^5.0.0`, peer `ai` `^7.0.0`
- **examples/node**: `ai` `^7.0.0`, `@ai-sdk/mcp` `^2.0.0`
- **examples/browser**: `ai` `^7.0.0`, `@ai-sdk/react` `^4.0.0`

Resolves to: `ai@7.0.0`, `@ai-sdk/provider@4.0.0`, `@ai-sdk/provider-utils@5.0.0`, `@ai-sdk/mcp@2.0.0`, `@ai-sdk/react@4.0.0`.

Caret-on-stable is safe now — the earlier "caret resolves to canary" gotcha only applied while the base was a prerelease.

## Changeset

Exited changeset pre/beta mode. The queued `ai-sdk-v7-support` changeset will version `3.8.7 → 4.0.0` final on the next `changeset version`.

## Docs

Refreshed both READMEs (root + package):
- Dropped stale "v7 beta" / "AI SDK v6" references for GA
- Stop-slop prose pass (de-hyped claims, removed emoji callouts)
- Fixed example bugs: `console.log(object)` → `output`; `parameters:`/`system:` → `inputSchema:`/`instructions:`

## Verification

- `type-check` ✓
- `build` ✓
- `242/242` unit tests ✓
- `check-exports` only errors because it shells to `npm pack` and corepack blocks `npm` in this repo (env quirk, not a package issue)

## Known issue (out of scope)

`pnpm lint` is red from the `eslint-plugin-unicorn 67→68` bump already merged on `main` (commit 885913f) — unrelated to v7. `lint:fix` cascades into a 30-file refactor and introduces `Array.fromAsync` (needs ES2024 `lib`; tsconfig is ES2022). Intentionally left for a separate PR.