### PR TITLE
style: clear eslint-plugin-unicorn 68 lint debt

### DIFF
--- a/packages/ai-sdk-ollama/README.md
+++ b/packages/ai-sdk-ollama/README.md
@@ -11,11 +11,11 @@ A Vercel AI SDK provider for Ollama, built on the official `ollama` package. Typ
 >
 > Each `ai-sdk-ollama` major targets one AI SDK major. Every line stays published on npm, so pick the one that matches your `ai` version:
 >
-> | `ai-sdk-ollama` | `ai` (peer) | Status |
-> | --- | --- | --- |
-> | `4.x` (`@latest`) | `ai@^7` | Active. New features land here. |
-> | `3.x` | `ai@^6` | Maintenance. Critical fixes only. |
-> | `2.x` | `ai@^5` | Unmaintained. |
+> | `ai-sdk-ollama`   | `ai` (peer) | Status                            |
+> | ----------------- | ----------- | --------------------------------- |
+> | `4.x` (`@latest`) | `ai@^7`     | Active. New features land here.   |
+> | `3.x`             | `ai@^6`     | Maintenance. Critical fixes only. |
+> | `2.x`             | `ai@^5`     | Unmaintained.                     |
 >
 > AI SDK v7 is stable, so v4 installs from `latest`. The v3 line still works for AI SDK v6.
 
@@ -413,12 +413,12 @@ const result = await generateText({
 
 **Standard vs Enhanced Comparison:**
 
-| Function                   | Standard `generateText`   | Enhanced `generateText`              |
-| -------------------------- | ------------------------- | ------------------------------------ |
-| **Simple prompts**         | ✅ Perfect                | ✅ Works (slight overhead)           |
-| **Tool calling**           | ⚠️ May return empty text  | ✅ **Returns complete responses**    |
-| **Complete responses**     | ❌ Manual handling needed | ✅ **Automatic completion**          |
-| **Production reliability** | ⚠️ Unpredictable          | ✅ **Reliable**                      |
+| Function                   | Standard `generateText`   | Enhanced `generateText`           |
+| -------------------------- | ------------------------- | --------------------------------- |
+| **Simple prompts**         | ✅ Perfect                | ✅ Works (slight overhead)        |
+| **Tool calling**           | ⚠️ May return empty text  | ✅ **Returns complete responses** |
+| **Complete responses**     | ❌ Manual handling needed | ✅ **Automatic completion**       |
+| **Production reliability** | ⚠️ Unpredictable          | ✅ **Reliable**                   |
 
 ### Simple and Predictable
 

--- a/packages/ai-sdk-ollama/src/functions/generate-text.ts
+++ b/packages/ai-sdk-ollama/src/functions/generate-text.ts
@@ -130,8 +130,8 @@ export async function generateText(
       // Build context with tool results
       const toolContext = toolResult.toolResults
         ?.map(
-          (tr, i) =>
-            `${toolResult.toolCalls?.[i]?.toolName}: ${JSON.stringify(tr.output ?? tr)}`,
+          (tr, index) =>
+            `${toolResult.toolCalls?.[index]?.toolName}: ${JSON.stringify(tr.output ?? tr)}`,
         )
         .join('\n');
 
@@ -221,9 +221,9 @@ export async function generateText(
       if (result.steps) {
         for (const step of result.steps) {
           if (step.toolCalls && step.toolResults) {
-            for (let i = 0; i < step.toolCalls.length; i++) {
-              const toolCall = step.toolCalls[i];
-              const toolResult = step.toolResults[i];
+            for (let index = 0; index < step.toolCalls.length; index++) {
+              const toolCall = step.toolCalls[index];
+              const toolResult = step.toolResults[index];
               if (toolCall && toolResult) {
                 allToolCalls.push({
                   toolName: toolCall.toolName,

--- a/packages/ai-sdk-ollama/src/functions/stream-text.ts
+++ b/packages/ai-sdk-ollama/src/functions/stream-text.ts
@@ -248,8 +248,14 @@ Based on the tool results above, please provide a comprehensive response to the 
               );
               if (synthesisText && !controllerClosed) {
                 const chunkSize = 20;
-                for (let i = 0; i < synthesisText.length; i += chunkSize) {
-                  if (!safeEnqueue(synthesisText.slice(i, i + chunkSize)))
+                for (
+                  let index = 0;
+                  index < synthesisText.length;
+                  index += chunkSize
+                ) {
+                  if (
+                    !safeEnqueue(synthesisText.slice(index, index + chunkSize))
+                  )
                     break;
                 }
               }
@@ -380,8 +386,12 @@ Based on the tool results above, please provide a comprehensive response to the 
                   safeEnqueue({ type: 'text-start', id: currentTextId });
 
                   const chunkSize = 10;
-                  for (let i = 0; i < synthesisText.length; i += chunkSize) {
-                    const chunk = synthesisText.slice(i, i + chunkSize);
+                  for (
+                    let index = 0;
+                    index < synthesisText.length;
+                    index += chunkSize
+                  ) {
+                    const chunk = synthesisText.slice(index, index + chunkSize);
                     safeEnqueue({
                       type: 'text-delta',
                       id: currentTextId,

--- a/packages/ai-sdk-ollama/src/integration-tests/advanced-features.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/advanced-features.test.ts
@@ -194,10 +194,7 @@ describe('Advanced Features Integration Tests', () => {
       maxOutputTokens: 200,
     });
 
-    const chunks: string[] = [];
-    for await (const textPart of result.textStream) {
-      chunks.push(textPart);
-    }
+    const chunks: string[] = await Array.fromAsync(result.textStream);
 
     const fullText = chunks.join('');
     expect(fullText).toBeTruthy();

--- a/packages/ai-sdk-ollama/src/integration-tests/auto-detection.int.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/auto-detection.int.test.ts
@@ -39,10 +39,9 @@ describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)(
         }),
       });
 
-      const partialObjects: Record<string, unknown>[] = [];
-      for await (const partialObject of result.partialOutputStream) {
-        partialObjects.push(partialObject);
-      }
+      const partialObjects: Record<string, unknown>[] = await Array.fromAsync(
+        result.partialOutputStream,
+      );
 
       expect(partialObjects.length).toBeGreaterThan(0);
 

--- a/packages/ai-sdk-ollama/src/integration-tests/auto-detection.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/auto-detection.test.ts
@@ -37,10 +37,9 @@ describe('Auto-Detection Integration Tests', () => {
       }),
     });
 
-    const partialObjects: Record<string, unknown>[] = [];
-    for await (const partialObject of result.partialOutputStream) {
-      partialObjects.push(partialObject);
-    }
+    const partialObjects: Record<string, unknown>[] = await Array.fromAsync(
+      result.partialOutputStream,
+    );
 
     expect(partialObjects.length).toBeGreaterThan(0);
 

--- a/packages/ai-sdk-ollama/src/integration-tests/error-handling.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/error-handling.test.ts
@@ -80,7 +80,7 @@ describe('Error Handling Integration Tests', () => {
 
   it('should handle extreme temperature values', async () => {
     // Very low temperature (deterministic)
-    const lowTempResult = await generateText({
+    const lowTemporaryResult = await generateText({
       model: ollama('llama3.2'),
       prompt: 'Complete: The sky is',
       maxOutputTokens: 10,
@@ -88,15 +88,15 @@ describe('Error Handling Integration Tests', () => {
     });
 
     // Very high temperature (random)
-    const highTempResult = await generateText({
+    const highTemporaryResult = await generateText({
       model: ollama('llama3.2'),
       prompt: 'Complete: The sky is',
       maxOutputTokens: 10,
       temperature: 2,
     });
 
-    expect(lowTempResult.text).toBeTruthy();
-    expect(highTempResult.text).toBeTruthy();
+    expect(lowTemporaryResult.text).toBeTruthy();
+    expect(highTemporaryResult.text).toBeTruthy();
   });
 
   it('should handle special characters in prompts', async () => {
@@ -128,10 +128,10 @@ describe('Error Handling Integration Tests', () => {
   });
 
   it('should handle concurrent requests', async () => {
-    const requests = Array.from({ length: 5 }, (_, i) =>
+    const requests = Array.from({ length: 5 }, (_, index) =>
       generateText({
         model: ollama('llama3.2'),
-        prompt: `Request ${i}: Say hello`,
+        prompt: `Request ${index}: Say hello`,
         maxOutputTokens: 20,
         temperature: 0,
       }),

--- a/packages/ai-sdk-ollama/src/integration-tests/generate-text.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/generate-text.test.ts
@@ -73,23 +73,23 @@ describe('Generate Text Integration Tests', () => {
   });
 
   it('should handle temperature settings', async () => {
-    const lowTempResult = await generateText({
+    const lowTemporaryResult = await generateText({
       model: ollama('llama3.2'),
       prompt: 'Complete this sentence: The weather is',
       maxOutputTokens: 10,
       temperature: 0,
     });
 
-    const highTempResult = await generateText({
+    const highTemporaryResult = await generateText({
       model: ollama('llama3.2'),
       prompt: 'Complete this sentence: The weather is',
       maxOutputTokens: 10,
       temperature: 0.9,
     });
 
-    expect(lowTempResult.text).toBeTruthy();
-    expect(highTempResult.text).toBeTruthy();
+    expect(lowTemporaryResult.text).toBeTruthy();
+    expect(highTemporaryResult.text).toBeTruthy();
     // High temperature should produce more varied results
-    expect(lowTempResult.text).not.toEqual(highTempResult.text);
+    expect(lowTemporaryResult.text).not.toEqual(highTemporaryResult.text);
   });
 });

--- a/packages/ai-sdk-ollama/src/integration-tests/gpt-oss-20b.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/gpt-oss-20b.test.ts
@@ -8,17 +8,16 @@ describe('GPT-OSS:20B Model Integration Tests', () => {
   const modelName = 'gpt-oss:20b';
 
   async function getNonEmptyText(
-    params: Parameters<typeof generateText>[0],
+    parameters: Parameters<typeof generateText>[0],
   ): Promise<string> {
     // 1) Try normal generation
-    const res = await generateText(params);
-    if (res.text && res.text.trim().length > 0) return res.text;
+    const result = await generateText(parameters);
+    if (result.text && result.text.trim().length > 0) return result.text;
 
     // 2) Try streaming fallback
     try {
-      const streamRes = await streamText(params);
-      const chunks: string[] = [];
-      for await (const c of streamRes.textStream) chunks.push(c);
+      const streamResult = await streamText(parameters);
+      const chunks: string[] = await Array.fromAsync(streamResult.textStream);
       const text = chunks.join('');
       if (text.trim().length > 0) return text;
     } catch {
@@ -27,19 +26,22 @@ describe('GPT-OSS:20B Model Integration Tests', () => {
 
     // 3) Retry with slightly different params
     const retry = await generateText({
-      ...params,
+      ...parameters,
       maxOutputTokens: Math.max(
         128,
-        typeof (params as { maxOutputTokens?: number }).maxOutputTokens ===
+        typeof (parameters as { maxOutputTokens?: number }).maxOutputTokens ===
           'number'
-          ? params.maxOutputTokens!
+          ? parameters.maxOutputTokens!
           : 0,
       ),
       temperature:
-        typeof (params as { temperature?: number }).temperature === 'number'
+        typeof (parameters as { temperature?: number }).temperature === 'number'
           ? Math.min(
               0.7,
-              Math.max(0.2, (params as { temperature?: number }).temperature!),
+              Math.max(
+                0.2,
+                (parameters as { temperature?: number }).temperature!,
+              ),
             )
           : 0.2,
       maxRetries: 2,
@@ -71,10 +73,7 @@ describe('GPT-OSS:20B Model Integration Tests', () => {
       temperature: 0,
     });
 
-    const chunks: string[] = [];
-    for await (const chunk of result.textStream) {
-      chunks.push(chunk);
-    }
+    const chunks: string[] = await Array.fromAsync(result.textStream);
 
     let fullText = chunks.join('');
     // Fallback: some models may not stream tokens; fetch a non-streamed result
@@ -167,14 +166,14 @@ describe('GPT-OSS:20B Model Integration Tests', () => {
       'pink',
       'brown',
     ];
-    const lowTempHasColor = colors.some((color) =>
+    const lowTemporaryHasColor = colors.some((color) =>
       lowText.toLowerCase().includes(color),
     );
-    const highTempHasColor = colors.some((color) =>
+    const highTemporaryHasColor = colors.some((color) =>
       highText.toLowerCase().includes(color),
     );
 
-    expect(lowTempHasColor || highTempHasColor).toBe(true);
+    expect(lowTemporaryHasColor || highTemporaryHasColor).toBe(true);
   });
 
   it('should handle token limits with gpt-oss:20b', async () => {

--- a/packages/ai-sdk-ollama/src/integration-tests/json-schema.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/json-schema.test.ts
@@ -51,10 +51,9 @@ describe('JSON Schema Integration Tests', { timeout: 120_000 }, () => {
       temperature: 0,
     });
 
-    const chunks: Record<string, unknown>[] = [];
-    for await (const chunk of result.partialOutputStream) {
-      chunks.push(chunk);
-    }
+    const chunks: Record<string, unknown>[] = await Array.fromAsync(
+      result.partialOutputStream,
+    );
 
     expect(chunks.length).toBeGreaterThan(0);
     const finalObject = chunks.at(-1);

--- a/packages/ai-sdk-ollama/src/integration-tests/messages.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/messages.test.ts
@@ -64,10 +64,7 @@ describe(
         temperature: 0.5,
       });
 
-      const chunks: string[] = [];
-      for await (const chunk of result.textStream) {
-        chunks.push(chunk);
-      }
+      const chunks: string[] = await Array.fromAsync(result.textStream);
 
       const fullText = chunks.join('');
       expect(fullText).toBeTruthy();

--- a/packages/ai-sdk-ollama/src/integration-tests/multimodal.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/multimodal.test.ts
@@ -77,10 +77,7 @@ describe('Multimodal Integration Tests', { timeout: 120_000 }, () => {
       temperature: 0,
     });
 
-    const chunks: string[] = [];
-    for await (const chunk of result.textStream) {
-      chunks.push(chunk);
-    }
+    const chunks: string[] = await Array.fromAsync(result.textStream);
 
     const fullText = chunks.join('');
     expect(fullText).toBeTruthy();

--- a/packages/ai-sdk-ollama/src/integration-tests/stream-object.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/stream-object.test.ts
@@ -24,10 +24,9 @@ describe('Stream Object Integration Tests', () => {
       }),
     });
 
-    const partialObjects: Record<string, unknown>[] = [];
-    for await (const partialObject of result.partialObjectStream) {
-      partialObjects.push(partialObject);
-    }
+    const partialObjects: Record<string, unknown>[] = await Array.fromAsync(
+      result.partialObjectStream,
+    );
 
     expect(partialObjects.length).toBeGreaterThan(0);
 
@@ -60,10 +59,9 @@ describe('Stream Object Integration Tests', () => {
       }),
     });
 
-    const partialObjects: Record<string, unknown>[] = [];
-    for await (const partialObject of result.partialObjectStream) {
-      partialObjects.push(partialObject);
-    }
+    const partialObjects: Record<string, unknown>[] = await Array.fromAsync(
+      result.partialObjectStream,
+    );
 
     expect(partialObjects.length).toBeGreaterThan(0);
 
@@ -94,10 +92,9 @@ describe('Stream Object Integration Tests', () => {
       }),
     });
 
-    const partialObjects: Record<string, unknown>[] = [];
-    for await (const partialObject of result.partialObjectStream) {
-      partialObjects.push(partialObject);
-    }
+    const partialObjects: Record<string, unknown>[] = await Array.fromAsync(
+      result.partialObjectStream,
+    );
 
     expect(partialObjects.length).toBeGreaterThan(0);
 
@@ -157,10 +154,9 @@ describe('Stream Object Integration Tests', () => {
       }),
     });
 
-    const partialObjects: Record<string, unknown>[] = [];
-    for await (const partialObject of result.partialObjectStream) {
-      partialObjects.push(partialObject);
-    }
+    const partialObjects: Record<string, unknown>[] = await Array.fromAsync(
+      result.partialObjectStream,
+    );
 
     expect(partialObjects.length).toBeGreaterThan(0);
 

--- a/packages/ai-sdk-ollama/src/integration-tests/stream-text.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/stream-text.test.ts
@@ -13,10 +13,7 @@ describe('Stream Text Integration Tests', () => {
       temperature: 0.3,
     });
 
-    const chunks: string[] = [];
-    for await (const textPart of result.textStream) {
-      chunks.push(textPart);
-    }
+    const chunks: string[] = await Array.fromAsync(result.textStream);
 
     const fullText = chunks.join('');
     expect(fullText).toBeTruthy();
@@ -40,10 +37,7 @@ describe('Stream Text Integration Tests', () => {
         temperature: 0,
       });
 
-      const chunks: string[] = [];
-      for await (const textPart of result.textStream) {
-        chunks.push(textPart);
-      }
+      const chunks: string[] = await Array.fromAsync(result.textStream);
 
       const fullText = chunks.join('');
       expect(fullText).toBeTruthy();
@@ -60,10 +54,7 @@ describe('Stream Text Integration Tests', () => {
       temperature: 0,
     });
 
-    const chunks: string[] = [];
-    for await (const textPart of result.textStream) {
-      chunks.push(textPart);
-    }
+    const chunks: string[] = await Array.fromAsync(result.textStream);
 
     const fullText = chunks.join('');
     expect(fullText).toBeTruthy();
@@ -96,38 +87,38 @@ describe('Stream Text Integration Tests', () => {
   });
 
   it('should handle streaming with temperature variations', async () => {
-    const lowTempResult = await streamText({
+    const lowTemporaryResult = await streamText({
       model: ollama('llama3.2'),
       prompt: 'Complete this sentence: The weather is',
       maxOutputTokens: 20,
       temperature: 0,
     });
 
-    const highTempResult = await streamText({
+    const highTemporaryResult = await streamText({
       model: ollama('llama3.2'),
       prompt: 'Complete this sentence: The weather is',
       maxOutputTokens: 20,
       temperature: 0.9,
     });
 
-    const lowTempChunks: string[] = [];
-    const highTempChunks: string[] = [];
+    const lowTemporaryChunks: string[] = [];
+    const highTemporaryChunks: string[] = [];
 
-    for await (const textPart of lowTempResult.textStream) {
-      lowTempChunks.push(textPart);
+    for await (const textPart of lowTemporaryResult.textStream) {
+      lowTemporaryChunks.push(textPart);
     }
 
-    for await (const textPart of highTempResult.textStream) {
-      highTempChunks.push(textPart);
+    for await (const textPart of highTemporaryResult.textStream) {
+      highTemporaryChunks.push(textPart);
     }
 
-    const lowTempText = lowTempChunks.join('');
-    const highTempText = highTempChunks.join('');
+    const lowTemporaryText = lowTemporaryChunks.join('');
+    const highTemporaryText = highTemporaryChunks.join('');
 
-    expect(lowTempText).toBeTruthy();
-    expect(highTempText).toBeTruthy();
-    expect(lowTempChunks.length).toBeGreaterThan(0);
-    expect(highTempChunks.length).toBeGreaterThan(0);
+    expect(lowTemporaryText).toBeTruthy();
+    expect(highTemporaryText).toBeTruthy();
+    expect(lowTemporaryChunks.length).toBeGreaterThan(0);
+    expect(highTemporaryChunks.length).toBeGreaterThan(0);
   });
 
   it('should handle streaming with structured outputs', async () => {
@@ -138,10 +129,7 @@ describe('Stream Text Integration Tests', () => {
       temperature: 0,
     });
 
-    const chunks: string[] = [];
-    for await (const textPart of result.textStream) {
-      chunks.push(textPart);
-    }
+    const chunks: string[] = await Array.fromAsync(result.textStream);
 
     const fullText = chunks.join('');
     expect(fullText).toBeTruthy();

--- a/packages/ai-sdk-ollama/src/integration-tests/streaming-metadata.test.ts
+++ b/packages/ai-sdk-ollama/src/integration-tests/streaming-metadata.test.ts
@@ -58,11 +58,7 @@ describe('Streaming Metadata Integration Tests', { timeout: 120_000 }, () => {
       temperature: 0.2,
     });
 
-    const chunks: string[] = [];
-
-    for await (const chunk of result.textStream) {
-      chunks.push(chunk);
-    }
+    const chunks: string[] = await Array.fromAsync(result.textStream);
 
     const fullText = chunks.join('');
 
@@ -124,7 +120,7 @@ describe('Streaming Metadata Integration Tests', { timeout: 120_000 }, () => {
     expect(eventLog.length).toBeGreaterThan(0);
 
     // Check for different event types
-    const eventTypes = eventLog.map((e) => e.type);
+    const eventTypes = eventLog.map((event) => event.type);
     expect(eventTypes).toContain('finish');
 
     // Should have at least some text or tool events
@@ -165,8 +161,10 @@ describe('Streaming Metadata Integration Tests', { timeout: 120_000 }, () => {
 
     // Analyze timing patterns
     const delays = [];
-    for (let i = 1; i < chunkTimings.length; i++) {
-      delays.push(chunkTimings[i]!.timestamp - chunkTimings[i - 1]!.timestamp);
+    for (let index = 1; index < chunkTimings.length; index++) {
+      delays.push(
+        chunkTimings[index]!.timestamp - chunkTimings[index - 1]!.timestamp,
+      );
     }
 
     // Calculate statistics

--- a/packages/ai-sdk-ollama/src/models/chat-language-model.test.ts
+++ b/packages/ai-sdk-ollama/src/models/chat-language-model.test.ts
@@ -532,11 +532,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await model.doStream(options);
-      const chunks = [];
-
-      for await (const chunk of stream) {
-        chunks.push(chunk);
-      }
+      const chunks = await Array.fromAsync(stream);
 
       expect(chunks).toHaveLength(7); // stream-start + text-start + 3 text-delta + text-end + finish
       // V3 adds stream-start at the beginning
@@ -648,11 +644,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await model.doStream(options);
-      const chunks = [];
-
-      for await (const chunk of stream) {
-        chunks.push(chunk);
-      }
+      const chunks = await Array.fromAsync(stream);
 
       expect(chunks).toEqual([
         {
@@ -985,11 +977,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await modelWithReasoning.doStream(options);
-      const chunks: LanguageModelV4StreamPart[] = [];
-
-      for await (const chunk of stream) {
-        chunks.push(chunk);
-      }
+      const chunks: LanguageModelV4StreamPart[] = await Array.fromAsync(stream);
 
       // Check that reasoning stream parts are emitted
       const reasoningStart = chunks.find(
@@ -1070,11 +1058,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await modelWithoutReasoning.doStream(options);
-      const chunks: LanguageModelV4StreamPart[] = [];
-
-      for await (const chunk of stream) {
-        chunks.push(chunk);
-      }
+      const chunks: LanguageModelV4StreamPart[] = await Array.fromAsync(stream);
 
       // Check that reasoning stream parts are NOT emitted
       const reasoningStart = chunks.find(
@@ -1194,11 +1178,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await modelWithReasoning.doStream(options);
-      const chunks: LanguageModelV4StreamPart[] = [];
-
-      for await (const chunk of stream) {
-        chunks.push(chunk);
-      }
+      const chunks: LanguageModelV4StreamPart[] = await Array.fromAsync(stream);
 
       // There should be exactly ONE reasoning-start and ONE reasoning-end
       const reasoningStarts = chunks.filter(
@@ -1296,11 +1276,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await model.doStream(options);
-      const chunks: LanguageModelV4StreamPart[] = [];
-
-      for await (const chunk of stream) {
-        chunks.push(chunk);
-      }
+      const chunks: LanguageModelV4StreamPart[] = await Array.fromAsync(stream);
 
       // Should have: stream-start, text-start, text-delta, text-delta, text-delta, text-end, finish
       expect(chunks).toHaveLength(7);
@@ -1373,11 +1349,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await model.doStream(options);
-      const chunks: LanguageModelV4StreamPart[] = [];
-
-      for await (const chunk of stream) {
-        chunks.push(chunk);
-      }
+      const chunks: LanguageModelV4StreamPart[] = await Array.fromAsync(stream);
 
       // Should have stream-start + finish (no text parts since content is empty)
       expect(chunks).toHaveLength(2);
@@ -1429,11 +1401,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await model.doStream(options);
-      const chunks: LanguageModelV4StreamPart[] = [];
-
-      for await (const chunk of stream) {
-        chunks.push(chunk);
-      }
+      const chunks: LanguageModelV4StreamPart[] = await Array.fromAsync(stream);
 
       // Should have: stream-start, text-start, text-delta, text-end, finish
       expect(chunks).toHaveLength(5);
@@ -1519,11 +1487,7 @@ describe('OllamaChatLanguageModel', () => {
       };
 
       const { stream } = await model.doStream(options);
-      const chunks: LanguageModelV4StreamPart[] = [];
-
-      for await (const chunk of stream) {
-        chunks.push(chunk);
-      }
+      const chunks: LanguageModelV4StreamPart[] = await Array.fromAsync(stream);
 
       // Extract text-related chunks
       const textStart = chunks.find((chunk) => chunk.type === 'text-start') as {

--- a/packages/ai-sdk-ollama/src/models/chat-language-model.ts
+++ b/packages/ai-sdk-ollama/src/models/chat-language-model.ts
@@ -476,7 +476,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
    * forced completion). Callers add the `stream: true | false` literal at the
    * call site so the Ollama client's streaming overload still resolves.
    */
-  private buildChatRequest(params: {
+  private buildChatRequest(parameters: {
     messages: OllamaMessage[];
     options: Record<string, unknown>;
     format?: string | Record<string, unknown>;
@@ -484,7 +484,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
     keep_alive?: string | number;
     think?: OllamaThink;
   }) {
-    const { messages, options, format, tools, keep_alive, think } = params;
+    const { messages, options, format, tools, keep_alive, think } = parameters;
     return {
       model: this.modelId,
       messages,
@@ -513,30 +513,30 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
     if (cleaned.properties && typeof cleaned.properties === 'object') {
       const cleanedProperties: Record<string, unknown> = {};
 
-      for (const [key, prop] of Object.entries(
+      for (const [key, property] of Object.entries(
         cleaned.properties as Record<string, unknown>,
       )) {
-        if (typeof prop === 'object' && prop !== null) {
-          const cleanedProp = { ...(prop as Record<string, unknown>) };
+        if (typeof property === 'object' && property !== null) {
+          const cleanedProperty = { ...(property as Record<string, unknown>) };
 
           // Remove complex regex patterns that Ollama can't handle
           // Keep format but remove pattern for email validation
-          if (cleanedProp.format === 'email' && cleanedProp.pattern) {
-            delete cleanedProp.pattern;
+          if (cleanedProperty.format === 'email' && cleanedProperty.pattern) {
+            delete cleanedProperty.pattern;
           }
 
           // Remove other complex patterns that might cause issues
           if (
-            typeof cleanedProp.pattern === 'string' &&
-            cleanedProp.pattern.length > 50
+            typeof cleanedProperty.pattern === 'string' &&
+            cleanedProperty.pattern.length > 50
           ) {
-            delete cleanedProp.pattern;
+            delete cleanedProperty.pattern;
           }
 
           // Recursively clean nested objects
-          cleanedProperties[key] = this.cleanSchemaForOllama(cleanedProp);
+          cleanedProperties[key] = this.cleanSchemaForOllama(cleanedProperty);
         } else {
-          cleanedProperties[key] = prop;
+          cleanedProperties[key] = property;
         }
       }
 
@@ -742,7 +742,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
     }
   }
 
-  private async performForceCompletion(params: {
+  private async performForceCompletion(parameters: {
     messages: OllamaMessage[];
     ollamaOptions: Record<string, unknown>;
     toolResults: Awaited<ReturnType<typeof executeReliableToolCalls>>;
@@ -757,7 +757,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
       originalOptions,
       format,
       keep_alive,
-    } = params;
+    } = parameters;
 
     const think = this.resolveThink(originalOptions);
 
@@ -830,7 +830,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
     };
   }
 
-  private buildGenerationResult(params: {
+  private buildGenerationResult(parameters: {
     messages: OllamaMessage[];
     ollamaOptions: Record<string, unknown>;
     format?: string | Record<string, unknown>;
@@ -864,7 +864,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
       reliable,
       finalTextOverride,
       think,
-    } = params;
+    } = parameters;
 
     const finalText = finalTextOverride ?? response.message.content ?? '';
     const thinking = response.message.thinking;
@@ -931,7 +931,9 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
       options: ollamaOptions,
       format,
       tools: ollamaTools,
-      ...(params.keep_alive !== undefined && { keep_alive: params.keep_alive }),
+      ...(parameters.keep_alive !== undefined && {
+        keep_alive: parameters.keep_alive,
+      }),
     };
 
     if (reliable) {
@@ -956,7 +958,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
     };
   }
 
-  private async callWithReliableToolHandling(params: {
+  private async callWithReliableToolHandling(parameters: {
     messages: OllamaMessage[];
     ollamaOptions: Record<string, unknown>;
     format?: string | Record<string, unknown>;
@@ -977,7 +979,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
       toolDefinitions,
       reliabilityOptions,
       keep_alive,
-    } = params;
+    } = parameters;
 
     const think = this.resolveThink(originalOptions);
 
@@ -1151,7 +1153,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
     );
   }
 
-  private async callWithReliableObjectGeneration(params: {
+  private async callWithReliableObjectGeneration(parameters: {
     messages: OllamaMessage[];
     ollamaOptions: Record<string, unknown>;
     format?: string | Record<string, unknown>;
@@ -1182,7 +1184,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
       schema,
       objectOptions,
       keep_alive,
-    } = params;
+    } = parameters;
 
     const think = this.resolveThink(originalOptions);
 
@@ -1295,7 +1297,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
     );
   }
 
-  private buildObjectGenerationResult(params: {
+  private buildObjectGenerationResult(parameters: {
     messages: OllamaMessage[];
     ollamaOptions: Record<string, unknown>;
     format?: string | Record<string, unknown>;
@@ -1315,7 +1317,7 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
     keep_alive?: string | number;
   }): GenerateResult {
     const { response, text, warnings, recoveryMethod, retryCount, errors } =
-      params;
+      parameters;
 
     // For object generation, we return the validated text as content
     const content: LanguageModelV4Content[] = [{ type: 'text', text }];
@@ -1363,13 +1365,13 @@ export class OllamaChatLanguageModel implements LanguageModelV4 {
       request: {
         body: {
           model: this.modelId,
-          messages: params.messages,
-          options: params.ollamaOptions,
-          format: params.format,
-          tools: params.tools,
+          messages: parameters.messages,
+          options: parameters.ollamaOptions,
+          format: parameters.format,
+          tools: parameters.tools,
           reliable_object_generation: true,
-          ...(params.keep_alive !== undefined && {
-            keep_alive: params.keep_alive,
+          ...(parameters.keep_alive !== undefined && {
+            keep_alive: parameters.keep_alive,
           }),
         },
       },

--- a/packages/ai-sdk-ollama/src/models/embedding-model.ts
+++ b/packages/ai-sdk-ollama/src/models/embedding-model.ts
@@ -32,7 +32,7 @@ export class OllamaEmbeddingModel implements EmbeddingModelV4 {
     return this.config.provider;
   }
 
-  async doEmbed(params: {
+  async doEmbed(parameters: {
     values: string[];
     abortSignal?: AbortSignal;
     providerOptions?: SharedV4ProviderOptions;
@@ -44,7 +44,7 @@ export class OllamaEmbeddingModel implements EmbeddingModelV4 {
     response?: { headers?: Record<string, string>; body?: unknown };
     warnings: SharedV4Warning[];
   }> {
-    const { values, abortSignal } = params;
+    const { values, abortSignal } = parameters;
     if (values.length > this.maxEmbeddingsPerCall) {
       throw new OllamaError({
         message: `Too many values to embed. Maximum: ${this.maxEmbeddingsPerCall}, Received: ${values.length}`,

--- a/packages/ai-sdk-ollama/src/models/embedding-reranking-model.test.ts
+++ b/packages/ai-sdk-ollama/src/models/embedding-reranking-model.test.ts
@@ -94,7 +94,7 @@ describe('OllamaEmbeddingRerankingModel', () => {
       expect(ranking[0]?.relevanceScore).toBeCloseTo(1, 5);
       // Document 2 (similar) should be second
       expect(ranking[1]?.index).toBe(2);
-      expect(ranking[1]?.relevanceScore).toBeCloseTo(0.7071, 3);
+      expect(ranking[1]?.relevanceScore).toBeCloseTo(Math.SQRT1_2, 3);
       // Document 1 (orthogonal) should be last
       expect(ranking[2]?.index).toBe(1);
       expect(ranking[2]?.relevanceScore).toBeCloseTo(0, 5);

--- a/packages/ai-sdk-ollama/src/models/embedding-reranking-model.ts
+++ b/packages/ai-sdk-ollama/src/models/embedding-reranking-model.ts
@@ -121,8 +121,8 @@ export class OllamaEmbeddingRerankingModel implements RerankingModelV4 {
     const batchSize = this.embeddingBatchSize;
     const embeddings: number[][] = [];
 
-    for (let i = 0; i < texts.length; i += batchSize) {
-      const batch = texts.slice(i, i + batchSize);
+    for (let index = 0; index < texts.length; index += batchSize) {
+      const batch = texts.slice(index, index + batchSize);
       const response = await this.config.client.embed({
         model,
         input: batch,
@@ -180,7 +180,7 @@ export class OllamaEmbeddingRerankingModel implements RerankingModelV4 {
       };
     }
 
-    const [queryEmbedding, ...docEmbeddings] = await this.embedBatch([
+    const [queryEmbedding, ...documentEmbeddings] = await this.embedBatch([
       query,
       ...documentValues,
     ]);
@@ -190,9 +190,9 @@ export class OllamaEmbeddingRerankingModel implements RerankingModelV4 {
     }
 
     // Calculate similarity scores
-    const scores = docEmbeddings.map((docEmb, index) => ({
+    const scores = documentEmbeddings.map((documentEmb, index) => ({
       index,
-      relevanceScore: cosineSimilarity(queryEmbedding, docEmb),
+      relevanceScore: cosineSimilarity(queryEmbedding, documentEmb),
     }));
 
     // Sort by score (descending) and limit to topN

--- a/packages/ai-sdk-ollama/src/models/image-model.ts
+++ b/packages/ai-sdk-ollama/src/models/image-model.ts
@@ -96,10 +96,10 @@ export class OllamaImageModel implements ImageModelV4 {
       }
     }
     if (seed != null) {
-      const opts = (
+      const options_ = (
         typeof body.options === 'object' && body.options ? body.options : {}
       ) as Record<string, unknown>;
-      body.options = { ...opts, seed };
+      body.options = { ...options_, seed };
     }
     const po = await parseProviderOptions({
       provider: 'ollama',
@@ -115,24 +115,25 @@ export class OllamaImageModel implements ImageModelV4 {
       ...optHeaders,
     };
 
-    const res = await (this.config.fetch ?? fetch)(url, {
+    const result = await (this.config.fetch ?? fetch)(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
       signal: abortSignal,
     });
 
-    if (!res.ok) {
-      const errBody = (await res.json().catch(() => ({}))) as {
+    if (!result.ok) {
+      const errorBody = (await result.json().catch(() => ({}))) as {
         error?: string;
       };
       throw new OllamaError({
         message:
-          errBody.error ?? `Ollama API error: ${res.status} ${res.statusText}`,
+          errorBody.error ??
+          `Ollama API error: ${result.status} ${result.statusText}`,
       });
     }
 
-    const data = (await res.json()) as {
+    const data = (await result.json()) as {
       model?: string;
       response?: string;
       images?: string[];
@@ -157,7 +158,7 @@ export class OllamaImageModel implements ImageModelV4 {
     }
 
     const responseHeaders: Record<string, string> = {};
-    for (const [key, value] of res.headers.entries()) {
+    for (const [key, value] of result.headers.entries()) {
       responseHeaders[key] = value;
     }
 

--- a/packages/ai-sdk-ollama/src/tool/web-fetch.test.ts
+++ b/packages/ai-sdk-ollama/src/tool/web-fetch.test.ts
@@ -79,7 +79,12 @@ describe('webFetch', () => {
     await expect(
       tool.execute!(
         { url: 'https://example.com' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
+        {
+          toolCallId: 'test',
+          messages: [],
+          abortSignal: undefined,
+          context: {},
+        },
       ),
     ).rejects.toThrow(OllamaError);
   });
@@ -136,7 +141,12 @@ describe('webFetch', () => {
       const tool = webFetch({ client: mockClient });
       const result = await tool.execute!(
         { url: 'https://example.com' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
+        {
+          toolCallId: 'test',
+          messages: [],
+          abortSignal: undefined,
+          context: {},
+        },
       );
 
       expect((result as any).error).toBe(testCase.expectedMessage);

--- a/packages/ai-sdk-ollama/src/tool/web-search.test.ts
+++ b/packages/ai-sdk-ollama/src/tool/web-search.test.ts
@@ -95,7 +95,12 @@ describe('webSearch', () => {
     await expect(
       tool.execute!(
         { query: 'test query' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
+        {
+          toolCallId: 'test',
+          messages: [],
+          abortSignal: undefined,
+          context: {},
+        },
       ),
     ).rejects.toThrow(OllamaError);
   });
@@ -108,7 +113,12 @@ describe('webSearch', () => {
     await expect(
       tool.execute!(
         { query: 'test query' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
+        {
+          toolCallId: 'test',
+          messages: [],
+          abortSignal: undefined,
+          context: {},
+        },
       ),
     ).rejects.toThrow(OllamaError);
   });
@@ -121,7 +131,12 @@ describe('webSearch', () => {
     await expect(
       tool.execute!(
         { query: 'test query' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
+        {
+          toolCallId: 'test',
+          messages: [],
+          abortSignal: undefined,
+          context: {},
+        },
       ),
     ).rejects.toThrow(OllamaError);
   });
@@ -134,7 +149,12 @@ describe('webSearch', () => {
     await expect(
       tool.execute!(
         { query: 'test query' },
-        { toolCallId: 'test', messages: [], abortSignal: undefined, context: {} },
+        {
+          toolCallId: 'test',
+          messages: [],
+          abortSignal: undefined,
+          context: {},
+        },
       ),
     ).rejects.toThrow(OllamaError);
   });

--- a/packages/ai-sdk-ollama/src/tool/web-search.ts
+++ b/packages/ai-sdk-ollama/src/tool/web-search.ts
@@ -102,7 +102,7 @@ export type WebSearchOutput = {
  */
 
 function hasWebSearch(client: unknown): client is {
-  webSearch: (args: Record<string, unknown>) => Promise<unknown>;
+  webSearch: (arguments_: Record<string, unknown>) => Promise<unknown>;
 } {
   if (!client || typeof client !== 'object') {
     return false;

--- a/packages/ai-sdk-ollama/src/utils/convert-to-ollama-messages.test.ts
+++ b/packages/ai-sdk-ollama/src/utils/convert-to-ollama-messages.test.ts
@@ -71,7 +71,10 @@ describe('convertToOllamaChatMessages', () => {
             { type: 'text', text: 'What is in this image?' },
             {
               type: 'file',
-              data: { type: 'url', url: new URL('https://example.com/image.jpg') },
+              data: {
+                type: 'url',
+                url: new URL('https://example.com/image.jpg'),
+              },
               mediaType: 'image/jpeg',
             },
           ],
@@ -97,7 +100,10 @@ describe('convertToOllamaChatMessages', () => {
             { type: 'text', text: 'Describe this image' },
             {
               type: 'file',
-              data: { type: 'data', data: 'data:image/jpeg;base64,/9j/4AAQ...' },
+              data: {
+                type: 'data',
+                data: 'data:image/jpeg;base64,/9j/4AAQ...',
+              },
               mediaType: 'image/jpeg',
             },
           ],
@@ -183,7 +189,10 @@ describe('convertToOllamaChatMessages', () => {
           content: [
             {
               type: 'file',
-              data: { type: 'url', url: new URL('https://example.com/image.jpg') },
+              data: {
+                type: 'url',
+                url: new URL('https://example.com/image.jpg'),
+              },
               mediaType: 'image/jpeg',
             },
           ],
@@ -922,7 +931,10 @@ describe('convertToOllamaChatMessages', () => {
         content: [
           {
             type: 'file',
-            data: { type: 'url', url: new URL('https://example.com/image.jpg') },
+            data: {
+              type: 'url',
+              url: new URL('https://example.com/image.jpg'),
+            },
             mediaType: 'image/jpeg',
           },
         ],

--- a/packages/ai-sdk-ollama/src/utils/convert-to-ollama-messages.ts
+++ b/packages/ai-sdk-ollama/src/utils/convert-to-ollama-messages.ts
@@ -131,18 +131,20 @@ export function convertToOllamaChatMessages(
 
           // Handle tool calls properly - Ollama DOES support native tool calls
           for (const part of message.content) {
-            if (part.type === 'tool-call') {
-              const args = parseToolArguments(part.input);
-
-              toolCalls.push({
-                id: part.toolCallId,
-                type: 'function',
-                function: {
-                  name: part.toolName,
-                  arguments: args,
-                },
-              });
+            if (part.type !== 'tool-call') {
+              continue;
             }
+
+            const arguments_ = parseToolArguments(part.input);
+
+            toolCalls.push({
+              id: part.toolCallId,
+              type: 'function',
+              function: {
+                name: part.toolName,
+                arguments: arguments_,
+              },
+            });
           }
         }
 

--- a/packages/ai-sdk-ollama/src/utils/cosine-similarity.test.ts
+++ b/packages/ai-sdk-ollama/src/utils/cosine-similarity.test.ts
@@ -24,7 +24,7 @@ describe('cosineSimilarity', () => {
     const a = [1 / Math.sqrt(2), 1 / Math.sqrt(2)];
     const b = [1, 0];
     // Angle is 45 degrees, cos(45) ≈ 0.707
-    expect(cosineSimilarity(a, b)).toBeCloseTo(0.7071, 3);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(Math.SQRT1_2, 3);
   });
 
   it('should throw error for vectors of different dimensions', () => {
@@ -47,8 +47,8 @@ describe('cosineSimilarity', () => {
 
   it('should handle high-dimensional vectors', () => {
     const dim = 768; // Common embedding dimension
-    const a = Array.from({ length: dim }, (_, i) => Math.sin(i));
-    const b = Array.from({ length: dim }, (_, i) => Math.sin(i + 0.1));
+    const a = Array.from({ length: dim }, (_, index) => Math.sin(index));
+    const b = Array.from({ length: dim }, (_, index) => Math.sin(index + 0.1));
     // Should be very similar but not identical
     const similarity = cosineSimilarity(a, b);
     expect(similarity).toBeGreaterThan(0.99);

--- a/packages/ai-sdk-ollama/src/utils/cosine-similarity.ts
+++ b/packages/ai-sdk-ollama/src/utils/cosine-similarity.ts
@@ -29,11 +29,11 @@ export function cosineSimilarity(a: number[], b: number[]): number {
   let magnitudeA = 0;
   let magnitudeB = 0;
 
-  for (const [i, aVal] of a.entries()) {
-    const bVal = b[i]!;
-    dotProduct += aVal * bVal;
-    magnitudeA += aVal * aVal;
-    magnitudeB += bVal * bVal;
+  for (const [index, aValue] of a.entries()) {
+    const bValue = b[index]!;
+    dotProduct += aValue * bValue;
+    magnitudeA += aValue * aValue;
+    magnitudeB += bValue * bValue;
   }
 
   magnitudeA = Math.sqrt(magnitudeA);

--- a/packages/ai-sdk-ollama/src/utils/object-generation-reliability.test.ts
+++ b/packages/ai-sdk-ollama/src/utils/object-generation-reliability.test.ts
@@ -365,8 +365,8 @@ describe('Enhanced JSON Repair', () => {
 
     it('should use repair function when JSON parsing fails', async () => {
       const input = '{"name": "John",}'; // trailing comma
-      const repairFn = getRepairFunction({});
-      const result = await parseJSONWithRepair(input, repairFn);
+      const repairFunction = getRepairFunction({});
+      const result = await parseJSONWithRepair(input, repairFunction);
       expect(result.success).toBe(true);
       expect(result.data).toEqual({ name: 'John' });
       expect(result.repaired).toBe(true);

--- a/packages/ai-sdk-ollama/src/utils/object-generation-reliability.ts
+++ b/packages/ai-sdk-ollama/src/utils/object-generation-reliability.ts
@@ -276,8 +276,8 @@ function generateBasicFallbackFromZod(schema: ZodSchema): unknown {
   }
 
   // Default fallback - try empty object for complex types
-  const objResult = schema.safeParse({});
-  if (objResult.success) {
+  const objectResult = schema.safeParse({});
+  if (objectResult.success) {
     return {};
   }
 
@@ -435,26 +435,26 @@ export function fixTypeMismatches(
  */
 function removeBlockCommentsOutsideStrings(text: string): string {
   let result = '';
-  let i = 0;
+  let index = 0;
   let inSingleQuote = false;
   let inDoubleQuote = false;
   let escaped = false;
 
-  while (i < text.length) {
-    const char = text[i];
-    const nextChar = text[i + 1];
+  while (index < text.length) {
+    const char = text[index];
+    const nextChar = text[index + 1];
 
     if (escaped) {
       result += char;
       escaped = false;
-      i++;
+      index++;
       continue;
     }
 
     if (char === '\\') {
       result += char;
       escaped = true;
-      i++;
+      index++;
       continue;
     }
 
@@ -462,31 +462,31 @@ function removeBlockCommentsOutsideStrings(text: string): string {
     if (char === "'" && !inDoubleQuote) {
       inSingleQuote = !inSingleQuote;
       result += char;
-      i++;
+      index++;
       continue;
     } else if (char === '"' && !inSingleQuote) {
       inDoubleQuote = !inDoubleQuote;
       result += char;
-      i++;
+      index++;
       continue;
     }
 
     // Check for block comment start /* when NOT inside a string
     if (char === '/' && nextChar === '*' && !inSingleQuote && !inDoubleQuote) {
       // Skip until we find */
-      i += 2; // Skip /*
-      while (i < text.length - 1) {
-        if (text[i] === '*' && text[i + 1] === '/') {
-          i += 2; // Skip */
+      index += 2; // Skip /*
+      while (index < text.length - 1) {
+        if (text[index] === '*' && text[index + 1] === '/') {
+          index += 2; // Skip */
           break;
         }
-        i++;
+        index++;
       }
       continue;
     }
 
     result += char;
-    i++;
+    index++;
   }
 
   return result;
@@ -497,25 +497,25 @@ function removeBlockCommentsOutsideStrings(text: string): string {
  */
 function replacePythonConstantsOutsideStrings(text: string): string {
   let result = '';
-  let i = 0;
+  let index = 0;
   let inSingleQuote = false;
   let inDoubleQuote = false;
   let escaped = false;
 
-  while (i < text.length) {
-    const char = text[i];
+  while (index < text.length) {
+    const char = text[index];
 
     if (escaped) {
       result += char;
       escaped = false;
-      i++;
+      index++;
       continue;
     }
 
     if (char === '\\') {
       result += char;
       escaped = true;
-      i++;
+      index++;
       continue;
     }
 
@@ -523,40 +523,40 @@ function replacePythonConstantsOutsideStrings(text: string): string {
     if (char === "'" && !inDoubleQuote) {
       inSingleQuote = !inSingleQuote;
       result += char;
-      i++;
+      index++;
       continue;
     } else if (char === '"' && !inSingleQuote) {
       inDoubleQuote = !inDoubleQuote;
       result += char;
-      i++;
+      index++;
       continue;
     }
 
     // Only process replacements when NOT inside a string
     if (!inSingleQuote && !inDoubleQuote) {
       // Check for Python constants with word boundaries
-      const remaining = text.slice(i);
+      const remaining = text.slice(index);
       const noneRegex = /^\bNone\b/;
       const trueRegex = /^\bTrue\b/;
       const falseRegex = /^\bFalse\b/;
 
       if (noneRegex.test(remaining)) {
         result += 'null';
-        i += 4; // Skip "None"
+        index += 4; // Skip "None"
         continue;
       } else if (trueRegex.test(remaining)) {
         result += 'true';
-        i += 4; // Skip "True"
+        index += 4; // Skip "True"
         continue;
       } else if (falseRegex.test(remaining)) {
         result += 'false';
-        i += 5; // Skip "False"
+        index += 5; // Skip "False"
         continue;
       }
     }
 
     result += char;
-    i++;
+    index++;
   }
 
   return result;
@@ -572,26 +572,26 @@ function replacePythonConstantsOutsideStrings(text: string): string {
  */
 function replaceSmartQuotesOutsideStrings(text: string): string {
   let result = '';
-  let i = 0;
+  let index = 0;
   let inSingleQuote = false;
   let inDoubleQuote = false;
   let inSmartDoubleQuote = false; // Track smart double quotes (\u201C and \u201D)
   let escaped = false;
 
-  while (i < text.length) {
-    const char = text[i];
+  while (index < text.length) {
+    const char = text[index];
 
     if (escaped) {
       result += char;
       escaped = false;
-      i++;
+      index++;
       continue;
     }
 
     if (char === '\\') {
       result += char;
       escaped = true;
-      i++;
+      index++;
       continue;
     }
 
@@ -599,12 +599,12 @@ function replaceSmartQuotesOutsideStrings(text: string): string {
     if (char === "'" && !inDoubleQuote && !inSmartDoubleQuote) {
       inSingleQuote = !inSingleQuote;
       result += char;
-      i++;
+      index++;
       continue;
     } else if (char === '"' && !inSingleQuote && !inSmartDoubleQuote) {
       inDoubleQuote = !inDoubleQuote;
       result += char;
-      i++;
+      index++;
       continue;
     } else if (
       char === '\u201C' &&
@@ -615,7 +615,7 @@ function replaceSmartQuotesOutsideStrings(text: string): string {
       // Opening smart double quote (\u201C) - start of smart-quoted string
       inSmartDoubleQuote = true;
       result += '"'; // Convert to regular quote
-      i++;
+      index++;
       continue;
     } else if (char === '\u201D' && inSmartDoubleQuote) {
       // Check if this is the closing quote by looking ahead
@@ -624,16 +624,16 @@ function replaceSmartQuotesOutsideStrings(text: string): string {
       // We'll use a heuristic: if we're at end-of-text OR the next non-whitespace
       // character is a structural character that cannot be inside a string value.
       let isClosing = false;
-      let j = i + 1;
+      let index_ = index + 1;
 
       // Skip whitespace
-      while (j < text.length) {
-        const nextChar = text[j];
+      while (index_ < text.length) {
+        const nextChar = text[index_];
         if (!nextChar) {
           break;
         }
         if (WHITESPACE_CHARS.has(nextChar)) {
-          j++;
+          index_++;
           continue;
         }
 
@@ -646,7 +646,7 @@ function replaceSmartQuotesOutsideStrings(text: string): string {
         // Check for , - this can be inside strings OR a field separator
         // If , is followed by whitespace and then a new key (starts with " or smart quote), it's likely closing a value
         if (nextChar === ',') {
-          let k = j + 1;
+          let k = index_ + 1;
           // Skip whitespace after comma
           while (k < text.length) {
             const afterComma = text[k];
@@ -702,7 +702,7 @@ function replaceSmartQuotesOutsideStrings(text: string): string {
         // Check for : - this is tricky because it can be inside strings OR a key-value separator
         // If : is followed by whitespace and then a value-starting character, it's likely closing a key
         if (nextChar === ':') {
-          let k = j + 1;
+          let k = index_ + 1;
           // Skip whitespace after colon
           while (k < text.length) {
             const afterColon = text[k];
@@ -730,7 +730,7 @@ function replaceSmartQuotesOutsideStrings(text: string): string {
       }
 
       // If we reached end-of-text (no more characters), it's closing
-      if (j >= text.length) {
+      if (index_ >= text.length) {
         isClosing = true;
       }
 
@@ -738,7 +738,7 @@ function replaceSmartQuotesOutsideStrings(text: string): string {
         // Closing smart double quote (\u201D) - end of smart-quoted string
         inSmartDoubleQuote = false;
         result += '"'; // Convert to regular quote
-        i++;
+        index++;
         continue;
       }
       // Otherwise, it's an inner smart quote - preserve it
@@ -749,20 +749,20 @@ function replaceSmartQuotesOutsideStrings(text: string): string {
       // Replace smart single quotes
       if (char !== undefined && SMART_SINGLE_QUOTE_CHARS.has(char)) {
         result += "'";
-        i++;
+        index++;
         continue;
       }
       // Replace smart double quotes when not used as delimiters
       if (char === '\u201C' || char === '\u201D') {
         result += '"';
-        i++;
+        index++;
         continue;
       }
     }
 
     // Inside strings (including smart-quoted strings), preserve all characters
     result += char;
-    i++;
+    index++;
   }
 
   return result;
@@ -851,9 +851,9 @@ export async function enhancedRepairText(options: {
         let escaped = false;
         let commentStart = -1;
 
-        for (let i = 0; i < line.length - 1; i++) {
-          const char = line[i];
-          const nextChar = line[i + 1];
+        for (let index = 0; index < line.length - 1; index++) {
+          const char = line[index];
+          const nextChar = line[index + 1];
 
           if (escaped) {
             // Skip this character, it's escaped
@@ -881,7 +881,7 @@ export async function enhancedRepairText(options: {
             !inSingleQuote &&
             !inDoubleQuote
           ) {
-            commentStart = i;
+            commentStart = index;
             break;
           }
         }
@@ -902,24 +902,24 @@ export async function enhancedRepairText(options: {
     // Walk through and convert single-quoted strings to double-quoted
     // This properly handles escaped quotes and doesn't touch single quotes inside double-quoted strings
     let result = '';
-    let i = 0;
+    let index = 0;
     let inDoubleQuote = false;
     let escaped = false;
 
-    while (i < repaired.length) {
-      const char = repaired[i];
+    while (index < repaired.length) {
+      const char = repaired[index];
 
       // Handle escape sequences
       if (escaped) {
         result += '\\' + char;
         escaped = false;
-        i++;
+        index++;
         continue;
       }
 
       if (char === '\\') {
         escaped = true;
-        i++;
+        index++;
         continue;
       }
 
@@ -927,7 +927,7 @@ export async function enhancedRepairText(options: {
       if (char === '"' && !escaped) {
         inDoubleQuote = !inDoubleQuote;
         result += char;
-        i++;
+        index++;
         continue;
       }
 
@@ -935,10 +935,10 @@ export async function enhancedRepairText(options: {
       if (char === "'" && !inDoubleQuote) {
         // Start of single-quoted string - convert to double quotes
         result += '"';
-        i++;
+        index++;
         let singleQuoteEscaped = false;
-        while (i < repaired.length) {
-          const innerChar = repaired[i];
+        while (index < repaired.length) {
+          const innerChar = repaired[index];
 
           if (singleQuoteEscaped) {
             // Keep escaped characters, but change \' to just '
@@ -947,33 +947,33 @@ export async function enhancedRepairText(options: {
                 ? "'" // Don't need to escape single quote in double-quoted string
                 : '\\' + innerChar;
             singleQuoteEscaped = false;
-            i++;
+            index++;
             continue;
           }
 
           if (innerChar === '\\') {
             singleQuoteEscaped = true;
-            i++;
+            index++;
             continue;
           }
 
           if (innerChar === "'") {
             // End of single-quoted string
             result += '"';
-            i++;
+            index++;
             break;
           }
 
           // Need to escape double quotes when converting from single to double quotes
           result += innerChar === '"' ? String.raw`\"` : innerChar;
-          i++;
+          index++;
         }
         continue;
       }
 
       // Regular character
       result += char;
-      i++;
+      index++;
     }
     repaired = result;
 
@@ -1308,40 +1308,40 @@ function coerceToSchemaType(
     parsedObject !== null &&
     !Array.isArray(parsedObject)
   ) {
-    const obj = parsedObject as Record<string, unknown>;
+    const object = parsedObject as Record<string, unknown>;
 
     // If object has an "elements" property that's an array, extract it
-    if (Array.isArray(obj.elements)) {
+    if (Array.isArray(object.elements)) {
       return {
-        coerced: obj.elements,
+        coerced: object.elements,
         wasCoerced: true,
       };
     }
 
     // If object has a "data" or "items" property that's an array, extract it
-    if (Array.isArray(obj.data)) {
+    if (Array.isArray(object.data)) {
       return {
-        coerced: obj.data,
+        coerced: object.data,
         wasCoerced: true,
       };
     }
-    if (Array.isArray(obj.items)) {
+    if (Array.isArray(object.items)) {
       return {
-        coerced: obj.items,
+        coerced: object.items,
         wasCoerced: true,
       };
     }
 
     // If the object has numeric keys (0, 1, 2...), convert to array
-    const keys = Object.keys(obj);
+    const keys = Object.keys(object);
     if (keys.every((k) => /^\d+$/.test(k))) {
       const maxIndex = Math.max(...keys.map(Number));
-      const arr: unknown[] = [];
-      for (let i = 0; i <= maxIndex; i++) {
-        arr.push(obj[String(i)]);
+      const array: unknown[] = [];
+      for (let index = 0; index <= maxIndex; index++) {
+        array.push(object[String(index)]);
       }
       return {
-        coerced: arr,
+        coerced: array,
         wasCoerced: true,
       };
     }
@@ -1618,7 +1618,7 @@ export async function attemptSchemaRecovery(
  * Create a reliable object generation wrapper
  */
 export function createReliableObjectGeneration<T>(
-  generateObjectFn: (
+  generateObjectFunction: (
     options: Record<string, unknown>,
   ) => Promise<{ object: T }>,
   schema: JSONSchema7 | unknown,
@@ -1633,7 +1633,7 @@ export function createReliableObjectGeneration<T>(
 
     for (let attempt = 1; attempt <= resolvedOptions.maxRetries; attempt++) {
       try {
-        const result = await generateObjectFn(generationOptions);
+        const result = await generateObjectFunction(generationOptions);
 
         // Try to validate the result
         const validation = await attemptSchemaRecovery(
@@ -1698,7 +1698,7 @@ export function createReliableObjectGeneration<T>(
  * Enhanced object generation with reliability features
  */
 export async function reliableGenerateObject<T>(
-  generateObjectFn: (
+  generateObjectFunction: (
     options: Record<string, unknown>,
   ) => Promise<{ object: T }>,
   options: Record<string, unknown>,
@@ -1706,7 +1706,7 @@ export async function reliableGenerateObject<T>(
   reliabilityOptions: ObjectGenerationOptions = {},
 ): Promise<ReliableObjectGenerationResult<T>> {
   const reliableGenerator = createReliableObjectGeneration(
-    generateObjectFn,
+    generateObjectFunction,
     schema,
     reliabilityOptions,
   );

--- a/packages/ai-sdk-ollama/src/utils/tool-calling-reliability.ts
+++ b/packages/ai-sdk-ollama/src/utils/tool-calling-reliability.ts
@@ -110,7 +110,7 @@ export interface ReliableToolCallResult {
 export interface ToolDefinition {
   description: string;
   inputSchema: Record<string, unknown>;
-  execute: (params: Record<string, unknown>) => Promise<unknown>;
+  execute: (parameters: Record<string, unknown>) => Promise<unknown>;
 }
 
 function ensureRecord(value: unknown): Record<string, unknown> {
@@ -182,7 +182,7 @@ export function createToolDefinitionMap(
           : { type: 'object', properties: {} },
       execute: (
         tool as LanguageModelV4FunctionTool & {
-          execute: (params: Record<string, unknown>) => Promise<unknown>;
+          execute: (parameters: Record<string, unknown>) => Promise<unknown>;
         }
       ).execute,
     };
@@ -310,24 +310,28 @@ export function extractToolResultsFromMessages(
     if (Array.isArray(message.content)) {
       for (const part of message.content) {
         if (
-          part &&
-          typeof part === 'object' &&
-          'type' in part &&
-          part.type === 'tool-result' &&
-          'toolName' in part &&
-          'output' in part
+          !(
+            part &&
+            typeof part === 'object' &&
+            'type' in part &&
+            part.type === 'tool-result' &&
+            'toolName' in part &&
+            'output' in part
+          )
         ) {
-          const toolResult = part as {
-            toolName: string;
-            output: unknown;
-            toolCallId?: string;
-          };
-          results.push({
-            toolName: toolResult.toolName,
-            result: toolResult.output,
-            toolCallId: toolResult.toolCallId,
-          });
+          continue;
         }
+
+        const toolResult = part as {
+          toolName: string;
+          output: unknown;
+          toolCallId?: string;
+        };
+        results.push({
+          toolName: toolResult.toolName,
+          result: toolResult.output,
+          toolCallId: toolResult.toolCallId,
+        });
       }
     } else if (message.content && typeof message.content === 'object') {
       // Handle single tool result object
@@ -407,12 +411,16 @@ export function normalizeToolParameters(
   for (const [standardName, variations] of Object.entries(mappings)) {
     for (const variation of variations) {
       if (
-        recordInput[variation] !== undefined &&
-        recordInput[variation] !== null
+        !(
+          recordInput[variation] !== undefined &&
+          recordInput[variation] !== null
+        )
       ) {
-        normalized[standardName] = recordInput[variation];
-        break;
+        continue;
       }
+
+      normalized[standardName] = recordInput[variation];
+      break;
     }
   }
 
@@ -433,7 +441,7 @@ export async function validateToolResult(
   _toolName: string,
   input: Record<string, unknown>,
   result: unknown,
-  executeFunction: (params: Record<string, unknown>) => Promise<unknown>,
+  executeFunction: (parameters: Record<string, unknown>) => Promise<unknown>,
   options: ToolCallingOptions = {},
 ): Promise<ToolCallResult> {
   const { normalizeParameters = true, parameterMappings } = options;

--- a/packages/ai-sdk-ollama/tsconfig.json
+++ b/packages/ai-sdk-ollama/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "ESNext.Array"],
     "types": ["node"],
     "moduleResolution": "bundler",
     "declaration": true,


### PR DESCRIPTION
## Summary

`main` has been red on `pnpm lint` since the `eslint-plugin-unicorn 67 → 68` bump (#1043) introduced new rules. This clears that debt.

Rules addressed:
- `unicorn/name-replacements` (e.g. `res` → `result`, `e` → `event`)
- `unicorn/prefer-continue`
- `unicorn/prefer-math-constants` (`0.7071` → `Math.SQRT1_2`)
- the `for await … push` → `Array.fromAsync` rewrite

Applied `eslint --fix`, hand-fixed the non-autofixable cases, and ran Prettier.

## tsconfig

The `Array.fromAsync` rewrites need a newer lib, so added `ESNext.Array` to `lib` (Node 22 supports `Array.fromAsync` at runtime). No emit/public-API change.

## Verification

- `lint` ✓
- `type-check` ✓
- `build` ✓
- `format:check` ✓
- `242/242` unit tests ✓